### PR TITLE
Tighten Excel add-in activation UX

### DIFF
--- a/ADDIN_ACTIVATION_CHECKLIST.md
+++ b/ADDIN_ACTIVATION_CHECKLIST.md
@@ -1,0 +1,28 @@
+# OilPrice Excel Add-in Activation Checklist
+
+Use this checklist before publishing customer setup instructions or linking the add-in as the primary Excel path.
+
+## Repository proof
+
+- `npm test -- --runInBand` passes.
+- `npm run build` passes.
+- `npx office-addin-manifest validate manifest.xml` passes.
+- Public copy avoids AppSource, workbook export, Power Query, WEBSERVICE/FILTERXML, macro, unlimited, realtime, SOC 2, 99.9 SLA, and unsupported coverage claims.
+
+## Windows Excel Desktop smoke
+
+Run this with a non-customer test API key. Do not paste the key in logs, screenshots, issues, or PRs.
+
+1. Sideload `manifest.xml` in Windows Excel Desktop.
+2. Confirm the OilPrice task pane opens from the ribbon.
+3. Paste the test API key, click **Save Key**, and confirm the pane reports `Key saved`.
+4. Click **Test Key** and confirm a plain success or plain quota/plan/rate-limit/auth error.
+5. Enter `=OILPRICE.PRICE("BRENT_CRUDE_USD")` and confirm it returns a numeric production value for a valid key.
+6. Put `BRENT_CRUDE_USD` in a worksheet cell, enter `=OILPRICE.PRICE(A1)`, then change the symbol cell and confirm the formula recalculates.
+7. Enter `=OILPRICE.GET("/v1/prices/latest","by_code=BRENT_CRUDE_USD")` and confirm it spills a readable table or a plain worksheet error.
+8. Confirm production API logs show the expected add-in request with `X-Excel-Addin-Version: 1.0.0`.
+9. Confirm no formula shows `#NAME?` after reload, workbook save/reopen, and recalculation.
+
+## Customer instructions gate
+
+Customer instructions are still blocked until the Windows Excel Desktop smoke passes. The supported-platform copy should state the exact tested Excel platforms and any unsupported Mac/web/mobile limitations from that smoke.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The customer-facing Excel path is the add-in. Other spreadsheet setup variants a
 
 Do not send customer instructions until Windows Excel smoke proves install, key save/test, production API log hit, formula recalculation after symbol change, and no `#NAME?`.
 
+See [ADDIN_ACTIVATION_CHECKLIST.md](ADDIN_ACTIVATION_CHECKLIST.md) for the proof checklist that gates customer instructions.
+
 ## Development
 
 ```bash

--- a/public/taskpane.js
+++ b/public/taskpane.js
@@ -28,10 +28,19 @@ async function storageGet(key) {
 }
 
 async function storageSet(key, value) {
+  let sharedStorageSaved = false;
+
   try {
     await OfficeRuntime.storage.setItem(key, value);
-  } finally {
-    localStorage.setItem(key, value);
+    sharedStorageSaved = true;
+  } catch {
+    // Formulas read OfficeRuntime.storage, so localStorage alone is not enough.
+  }
+
+  localStorage.setItem(key, value);
+
+  if (!sharedStorageSaved) {
+    throw new Error("SHARED_STORAGE_UNAVAILABLE");
   }
 }
 
@@ -61,10 +70,17 @@ async function saveApiKey() {
     return;
   }
 
-  await storageSet(API_KEY_STORAGE, apiKey);
-  if (input) input.value = "";
-  showStatus("API key saved. Use Formulas > Calculate Now to refresh formulas.");
-  setConnectionStatus("Key saved", "success");
+  try {
+    await storageSet(API_KEY_STORAGE, apiKey);
+    if (input) input.value = "";
+    showStatus("API key saved. Use Formulas > Calculate Now to refresh formulas.");
+    setConnectionStatus("Key saved", "success");
+  } catch {
+    setConnectionStatus("Storage unavailable", "error");
+    showError(
+      "Excel could not save the shared add-in key. Close and reopen the add-in, then try again.",
+    );
+  }
 }
 
 async function clearApiKey() {
@@ -107,6 +123,12 @@ async function testConnection() {
     if (response.status === 429) {
       setConnectionStatus("Rate limited", "error");
       showError("Rate limit reached. Try later.");
+      return;
+    }
+
+    if (response.status === 402 || response.status === 403) {
+      setConnectionStatus("Plan or quota limit", "error");
+      showError("Quota or plan limit reached for this API key.");
       return;
     }
 


### PR DESCRIPTION
## Summary
- make task pane key save fail visibly when Office shared storage is unavailable, because formulas read OfficeRuntime.storage
- map 402/403 key tests to plain quota/plan messages
- add an activation checklist that gates customer instructions on Windows Excel Desktop proof

## Validation
- npm test -- --runInBand
- npm run build
- npx office-addin-manifest validate manifest.xml
- rg claim scan across current public add-in docs/pages

## Remaining blocker
- No Windows Excel Desktop smoke was run from this Linux environment. Customer instructions remain blocked until sideload, key save/test, production API hit, OILPRICE.PRICE/OILPRICE.GET, recalc after symbol change, and no #NAME? are proven in Windows Excel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive pre-release validation checklist for add-in deployment and testing procedures.

* **Bug Fixes**
  * Improved storage system with automatic fallback when unavailable.
  * Enhanced error messaging for API quota and plan limit scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OilpriceAPI/excel-energy-addin/pull/14)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->