### PR TITLE
Add Excel task pane support diagnostics

### DIFF
--- a/ADDIN_ACTIVATION_CHECKLIST.md
+++ b/ADDIN_ACTIVATION_CHECKLIST.md
@@ -18,11 +18,12 @@ Run this with a non-customer test API key. Do not paste the key in logs, screens
 2. Confirm the OilPrice task pane opens from the ribbon.
 3. Paste the test API key, click **Save Key**, and confirm the pane reports `Key saved`.
 4. Click **Test Key** and confirm a plain success or plain quota/plan/rate-limit/auth error.
-5. Enter `=OILPRICE.PRICE("BRENT_CRUDE_USD")` and confirm it returns a numeric production value for a valid key.
-6. Put `BRENT_CRUDE_USD` in a worksheet cell, enter `=OILPRICE.PRICE(A1)`, then change the symbol cell and confirm the formula recalculates.
-7. Enter `=OILPRICE.GET("/v1/prices/latest","by_code=BRENT_CRUDE_USD")` and confirm it spills a readable table or a plain worksheet error.
-8. Confirm production API logs show the expected add-in request with `X-Excel-Addin-Version: 1.0.0`.
-9. Confirm no formula shows `#NAME?` after reload, workbook save/reopen, and recalculation.
+5. Click **Copy Diagnostics** and confirm the copied text includes version, Excel host/platform, shared-storage state, last test status, last endpoint, and no API key.
+6. Enter `=OILPRICE.PRICE("BRENT_CRUDE_USD")` and confirm it returns a numeric production value for a valid key.
+7. Put `BRENT_CRUDE_USD` in a worksheet cell, enter `=OILPRICE.PRICE(A1)`, then change the symbol cell and confirm the formula recalculates.
+8. Enter `=OILPRICE.GET("/v1/prices/latest","by_code=BRENT_CRUDE_USD")` and confirm it spills a readable table or a plain worksheet error.
+9. Confirm production API logs show the expected add-in request with `X-Excel-Addin-Version: 1.0.0`.
+10. Confirm no formula shows `#NAME?` after reload, workbook save/reopen, and recalculation.
 
 ## Customer Instructions Gate
 

--- a/public/taskpane.css
+++ b/public/taskpane.css
@@ -203,6 +203,44 @@ button {
   color: #ea4335;
 }
 
+/* Diagnostics */
+.diagnostics-section {
+  padding: 12px;
+  background: #fafafa;
+  border: 1px solid #e6e6e6;
+  border-radius: 4px;
+}
+
+.diagnostics-list {
+  margin-bottom: 12px;
+}
+
+.diagnostics-list div {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.diagnostics-list dt {
+  font-size: 11px;
+  font-weight: 600;
+  color: #666;
+}
+
+.diagnostics-list dd {
+  font-size: 11px;
+  color: #222;
+  word-break: break-word;
+}
+
+.diagnostics-note {
+  margin-top: 8px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: #666;
+}
+
 /* Help Section */
 .help-section {
   margin-top: 24px;

--- a/public/taskpane.html
+++ b/public/taskpane.html
@@ -56,6 +56,30 @@
         <div id="error-message" class="error-message"></div>
       </section>
 
+      <section class="diagnostics-section">
+        <h2>Diagnostics</h2>
+        <dl class="diagnostics-list">
+          <div>
+            <dt>Version</dt>
+            <dd id="diag-version">1.0.0</dd>
+          </div>
+          <div>
+            <dt>Excel</dt>
+            <dd id="diag-excel">Detecting</dd>
+          </div>
+          <div>
+            <dt>Storage</dt>
+            <dd id="diag-storage">Detecting</dd>
+          </div>
+          <div>
+            <dt>Last test</dt>
+            <dd id="diag-last-test">Not tested</dd>
+          </div>
+        </dl>
+        <button id="copy-diagnostics-btn" class="btn-secondary" type="button">Copy Diagnostics</button>
+        <p class="diagnostics-note">Copies version, Excel host, storage state, and last test result. API keys are never copied.</p>
+      </section>
+
       <section class="help-section">
         <details>
           <summary>Formula errors</summary>

--- a/public/taskpane.js
+++ b/public/taskpane.js
@@ -1,15 +1,38 @@
 /* global Office, OfficeRuntime */
 
 const API_KEY_STORAGE = "oilpriceapi_key";
+const ADDIN_VERSION = "1.0.0";
 const TEST_URL =
   "https://api.oilpriceapi.com/v1/prices/latest?by_code=BRENT_CRUDE_USD";
+const TEST_ENDPOINT_LABEL = "/v1/prices/latest?by_code=BRENT_CRUDE_USD";
+
+const diagnostics = {
+  version: ADDIN_VERSION,
+  host: "Unknown",
+  platform: "Unknown",
+  storage: "Unknown",
+  lastTest: "Not tested",
+  lastHttpStatus: "",
+  lastEndpoint: TEST_ENDPOINT_LABEL,
+  lastTestAt: "",
+};
 
 Office.onReady((info) => {
   if (info.host !== Office.HostType.Excel) {
+    updateDiagnostics({
+      host: info.host || "Unknown",
+      platform: info.platform || "Unknown",
+      storage: sharedStorageLabel(),
+    });
     showError("Open this pane from Excel to save and test an API key.");
     return;
   }
 
+  updateDiagnostics({
+    host: info.host || "Excel",
+    platform: info.platform || "Unknown",
+    storage: sharedStorageLabel(),
+  });
   setupEventListeners();
   loadApiKeyState();
 });
@@ -20,6 +43,9 @@ function setupEventListeners() {
     .getElementById("test-connection-btn")
     ?.addEventListener("click", testConnection);
   document.getElementById("clear-key-btn")?.addEventListener("click", clearApiKey);
+  document
+    .getElementById("copy-diagnostics-btn")
+    ?.addEventListener("click", copyDiagnostics);
 }
 
 async function storageGet(key) {
@@ -70,7 +96,12 @@ function hasSharedStorage() {
   );
 }
 
+function sharedStorageLabel() {
+  return hasSharedStorage() ? "Available" : "Unavailable";
+}
+
 async function loadApiKeyState() {
+  updateDiagnostics({ storage: sharedStorageLabel() });
   try {
     const apiKey = await storageGet(API_KEY_STORAGE);
     if (apiKey) {
@@ -92,10 +123,12 @@ async function saveApiKey() {
 
   try {
     await storageSet(API_KEY_STORAGE, apiKey);
+    updateDiagnostics({ storage: "Available" });
     if (input) input.value = "";
     showStatus("API key saved. Use Formulas > Calculate Now to refresh formulas.");
     setConnectionStatus("Key saved", "success");
   } catch {
+    updateDiagnostics({ storage: "Unavailable" });
     setConnectionStatus("Storage unavailable", "error");
     showError("Excel shared storage is unavailable. Reload the add-in, then save the key again.");
   }
@@ -104,9 +137,11 @@ async function saveApiKey() {
 async function clearApiKey() {
   try {
     await storageRemove(API_KEY_STORAGE);
+    updateDiagnostics({ storage: sharedStorageLabel() });
     setConnectionStatus("No key saved", "");
     showStatus("API key cleared.");
   } catch {
+    updateDiagnostics({ storage: "Unavailable" });
     setConnectionStatus("Storage unavailable", "error");
     showError("Excel shared storage is unavailable. Reload the add-in, then try again.");
   }
@@ -116,18 +151,23 @@ async function testConnection() {
   let apiKey;
   try {
     apiKey = await storageGet(API_KEY_STORAGE);
+    updateDiagnostics({ storage: "Available" });
   } catch {
+    updateDiagnostics({ storage: "Unavailable" });
+    recordConnectionResult("Storage unavailable");
     setConnectionStatus("Storage unavailable", "error");
     showError("Excel shared storage is unavailable. Reload the add-in, save the key, then test again.");
     return;
   }
 
   if (!apiKey) {
+    recordConnectionResult("No key saved");
     showError("Save an API key before testing.");
     setConnectionStatus("No key", "error");
     return;
   }
 
+  recordConnectionResult("Testing");
   setConnectionStatus("Testing...", "");
 
   try {
@@ -135,52 +175,130 @@ async function testConnection() {
       headers: {
         Authorization: `Token ${apiKey}`,
         "Content-Type": "application/json",
-        "X-Excel-Addin-Version": "1.0.0",
+        "X-Excel-Addin-Version": ADDIN_VERSION,
       },
     });
 
     if (response.ok) {
+      recordConnectionResult("Connected", response.status);
       setConnectionStatus("Connected", "success");
       showStatus("Connected to OilPriceAPI.");
       return;
     }
 
     if (response.status === 401) {
+      recordConnectionResult("Invalid key", response.status);
       setConnectionStatus("Invalid key", "error");
       showError("API key invalid or expired.");
       return;
     }
 
     if (response.status === 402) {
+      recordConnectionResult("Quota reached", response.status);
       setConnectionStatus("Quota reached", "error");
       showError("Quota or plan limit reached.");
       return;
     }
 
     if (response.status === 403) {
+      recordConnectionResult("Upgrade required", response.status);
       setConnectionStatus("Upgrade required", "error");
       showError("Your plan does not include this endpoint.");
       return;
     }
 
     if (response.status === 429) {
+      recordConnectionResult("Rate limited", response.status);
       setConnectionStatus("Rate limited", "error");
       showError("Rate limit reached. Try later.");
       return;
     }
 
     if (response.status >= 500) {
+      recordConnectionResult("Server error", response.status);
       setConnectionStatus("Server error", "error");
       showError("OilPriceAPI is temporarily unavailable.");
       return;
     }
 
+    recordConnectionResult(`HTTP ${response.status}`, response.status);
     setConnectionStatus(`HTTP ${response.status}`, "error");
     showError(`OilPriceAPI returned HTTP ${response.status}.`);
   } catch {
+    recordConnectionResult("Network error");
     setConnectionStatus("Network error", "error");
     showError("Cannot reach OilPriceAPI. Check your connection.");
   }
+}
+
+function recordConnectionResult(label, httpStatus = "") {
+  updateDiagnostics({
+    lastTest: label,
+    lastHttpStatus: httpStatus ? String(httpStatus) : "",
+    lastEndpoint: TEST_ENDPOINT_LABEL,
+    lastTestAt: new Date().toISOString(),
+  });
+}
+
+function updateDiagnostics(next) {
+  Object.assign(diagnostics, next);
+
+  setText("diag-version", diagnostics.version);
+  setText(
+    "diag-excel",
+    `${diagnostics.host || "Unknown"} / ${diagnostics.platform || "Unknown"}`,
+  );
+  setText("diag-storage", diagnostics.storage || "Unknown");
+  setText("diag-last-test", formatLastTest());
+}
+
+function formatLastTest() {
+  const parts = [diagnostics.lastTest || "Not tested"];
+  if (diagnostics.lastHttpStatus) parts.push(`HTTP ${diagnostics.lastHttpStatus}`);
+  if (diagnostics.lastTestAt) parts.push(diagnostics.lastTestAt);
+  return parts.join(" / ");
+}
+
+function setText(id, text) {
+  const element = document.getElementById(id);
+  if (element) element.textContent = text;
+}
+
+async function copyDiagnostics() {
+  const text = [
+    `OilPrice Excel Add-in diagnostics`,
+    `Version: ${diagnostics.version}`,
+    `Excel: ${diagnostics.host || "Unknown"} / ${diagnostics.platform || "Unknown"}`,
+    `Shared storage: ${diagnostics.storage || "Unknown"}`,
+    `Last test: ${diagnostics.lastTest || "Not tested"}`,
+    `Last HTTP status: ${diagnostics.lastHttpStatus || "none"}`,
+    `Last endpoint: ${diagnostics.lastEndpoint || TEST_ENDPOINT_LABEL}`,
+    `Last test at: ${diagnostics.lastTestAt || "not tested"}`,
+  ].join("\n");
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+    } else {
+      copyTextFallback(text);
+    }
+    showStatus("Diagnostics copied.");
+  } catch {
+    copyTextFallback(text);
+    showStatus("Diagnostics copied.");
+  }
+}
+
+function copyTextFallback(text) {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand("copy");
+  document.body.removeChild(textarea);
 }
 
 function setConnectionStatus(message, state) {


### PR DESCRIPTION
## Why

The add-in needs to be supportable without asking users for API keys,
screenshots full of secrets, or a phone call. The task pane should give support
copy-safe runtime facts when install/key/formula issues happen.

## What

- Adds a compact **Diagnostics** section to the task pane.
- Shows add-in version, Excel host/platform, shared-storage state, and last key-test result.
- Adds **Copy Diagnostics** output with version, host/platform, storage state, last endpoint, last status, and timestamp.
- Keeps copied diagnostics key-free.
- Adds the diagnostics check to the activation checklist.

## Validation

- `npm test -- --runInBand` PASS.
- `npm run build` PASS.
- `git diff --check` PASS.
- Manual leak review: copied diagnostics only include static endpoint/status/platform/version fields, not API key material.

## Guardrails

This improves supportability but does not unblock customer instructions. #12
still needs Windows Excel runtime proof; #16 still owns customer distribution;
#20 still owns safe all-endpoint coverage.
