### PR TITLE
Avoid custom CORS header in Excel runtime

### DIFF
--- a/ADDIN_ACTIVATION_CHECKLIST.md
+++ b/ADDIN_ACTIVATION_CHECKLIST.md
@@ -22,7 +22,7 @@ Run this with a non-customer test API key. Do not paste the key in logs, screens
 6. Enter `=OILPRICE.PRICE("BRENT_CRUDE_USD")` and confirm it returns a numeric production value for a valid key.
 7. Put `BRENT_CRUDE_USD` in a worksheet cell, enter `=OILPRICE.PRICE(A1)`, then change the symbol cell and confirm the formula recalculates.
 8. Enter `=OILPRICE.GET("/v1/prices/latest","by_code=BRENT_CRUDE_USD")` and confirm it spills a readable table or a plain worksheet error.
-9. Confirm production API logs show the expected add-in request with `X-Excel-Addin-Version: 1.0.0`.
+9. Confirm production API logs show the expected add-in request for the non-customer test account and the browser request shape is limited to `authorization,content-type`.
 10. Confirm no formula shows `#NAME?` after reload, workbook save/reopen, and recalculation.
 
 ## Customer Instructions Gate

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -22,7 +22,7 @@ All gates must be green before support or marketing sends customer install instr
    - `OILPRICE.PRICE` returns production data;
    - cell-reference recalc works after symbol change;
    - `OILPRICE.GET` returns a readable table;
-   - production logs show `X-Excel-Addin-Version: 1.0.0`;
+   - production logs show the expected non-customer test-account request and the browser request shape is limited to `authorization,content-type`;
    - no raw API key appears in logs, screenshots, GitHub, or support text.
 2. Hosted assets pass:
    - `manifest.xml`, `functions.json`, `functions.js`, and `taskpane.html` return HTTP 200;
@@ -141,6 +141,6 @@ Track:
 - first successful formula call;
 - common worksheet errors;
 - support tickets per install;
-- API errors with `X-Excel-Addin-Version`.
+- API request IDs, status codes, and task-pane diagnostics for formula/test failures.
 
 Escalate if support tickets per install are nonzero for the same setup step.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,7 +94,7 @@ Confirm the production API saw the add-in request:
 
 - expected endpoint: `/v1/prices/latest`;
 - expected code: `BRENT_CRUDE_USD`;
-- expected header: `X-Excel-Addin-Version: 1.0.0`;
+- expected browser request headers: `authorization,content-type`;
 - expected user/key: the non-customer test account;
 - no raw API key exposure.
 

--- a/public/taskpane.js
+++ b/public/taskpane.js
@@ -175,7 +175,6 @@ async function testConnection() {
       headers: {
         Authorization: `Token ${apiKey}`,
         "Content-Type": "application/json",
-        "X-Excel-Addin-Version": ADDIN_VERSION,
       },
     });
 

--- a/src/functions/functions.ts
+++ b/src/functions/functions.ts
@@ -264,7 +264,6 @@ async function apiGet(path: string, query: string | undefined, apiKey: string): 
     headers: {
       Authorization: `Token ${apiKey}`,
       "Content-Type": "application/json",
-      "X-Excel-Addin-Version": "1.0.0",
     },
   });
 

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -363,7 +363,6 @@ export class OilPriceAPIClient {
         headers: {
           Authorization: `Token ${this.apiKey}`,
           "Content-Type": "application/json",
-          "X-Excel-Addin-Version": "1.0.0",
         },
       });
 
@@ -486,7 +485,6 @@ export class OilPriceAPIClient {
         headers: {
           Authorization: `Token ${this.apiKey}`,
           "Content-Type": "application/json",
-          "X-Excel-Addin-Version": "1.0.0",
         },
       });
 

--- a/tests/unit/functions.test.ts
+++ b/tests/unit/functions.test.ts
@@ -38,7 +38,6 @@ describe("OilPrice custom functions MVP", () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: "Token test-api-key-123",
-            "X-Excel-Addin-Version": "1.0.0",
           }),
         }),
       );


### PR DESCRIPTION
## Summary
- remove the nonessential X-Excel-Addin-Version request header from task-pane and custom-function API calls
- keep the runtime on the public api.oilpriceapi.com origin instead of using a fallback DigitalOcean ingress URL
- update the focused unit assertion to match the browser-safe request shape

## Validation
- npm test -- --runInBand
- npm run build
- git diff --check -- public/taskpane.js src/functions/functions.ts src/utils/api-client.ts tests/unit/functions.test.ts
- live CORS probe: api.oilpriceapi.com OPTIONS succeeds when the add-in requests authorization,content-type only

## Notes
This unblocks the Excel Online runtime path while infra separately removes the stale custom-domain CORS header override that still omits X-Excel-Addin-Version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed custom version header from API requests for improved compatibility.
  
* **Tests**
  * Updated test assertions to reflect header removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->