### PR TITLE
Align Excel add-in toolchain on Node 20

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,7 +8,7 @@ This guide is for contributors working on the add-in source code. For **installa
 
 ## Prerequisites
 
-- Node.js 18+
+- Node.js 20.9+
 - npm
 - Microsoft Excel (for testing)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "excel-energy-addin",
       "version": "1.0.0",
       "license": "MIT",
+      "engines": {
+        "node": ">=20.9.0"
+      },
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/office-js": "^1.0.544",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "author": "OilPriceAPI",
   "license": "MIT",
   "type": "commonjs",
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/office-js": "^1.0.544",


### PR DESCRIPTION
## Summary
- Set the GitHub Pages build workflow to Node 20 and current checkout/setup-node actions
- Document Node 20.9+ as the contributor runtime
- Add the same Node 20.9+ engine floor to package metadata

## Why
Dependabot PRs for the remaining Excel add-in dependency security fixes include dev-tool major updates that require Node.js 20.9+. This makes the runtime expectation explicit before merging those updates.

## Verification
- npm ci
- npm test -- --runInBand
- npm run build
- npx office-addin-manifest validate manifest.xml
- npm audit --omit=dev --audit-level=moderate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Pages deployment environment to use Node.js 20 and newer build actions.
  * Added a minimum Node.js version requirement of 20.9.0.

* **Documentation**
  * Updated development prerequisites to require Node.js 20.9 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->