### PR TITLE
Redact legacy API keys from docs

### DIFF
--- a/docs/legacy/DEPLOYMENT_SUCCESS.md
+++ b/docs/legacy/DEPLOYMENT_SUCCESS.md
@@ -61,7 +61,7 @@ Your Excel Energy Price Comparison add-in is now **fully deployed** and accessib
 3. **Open Add-in**
    - Add-in appears in Home ribbon
    - Click to open taskpane
-   - Enter API key: `3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11`
+   - Enter API key: `[REDACTED - do not commit API keys]`
    - Click "Fetch Prices"
 
 4. **Verify Features**

--- a/docs/legacy/FIX_UK_NATURAL_GAS.md
+++ b/docs/legacy/FIX_UK_NATURAL_GAS.md
@@ -62,7 +62,7 @@ NATURAL_GAS_GBP | 750.00 | GBp | therm | $9.93 | 0.1 | $9.93
 
 ### Step 2: Fetch Prices Again
 
-1. Enter API key: `3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11`
+1. Enter API key: `[REDACTED - do not commit API keys]`
 2. Select commodities (including NATURAL_GAS_GBP)
 3. Click "Fetch Prices"
 4. Click "Convert to MBtu"

--- a/docs/legacy/QUICK_TEST_GUIDE.md
+++ b/docs/legacy/QUICK_TEST_GUIDE.md
@@ -27,7 +27,7 @@
 
 2. **Enter your admin API key:**
    ```
-   3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11
+   [REDACTED - do not commit API keys]
    ```
 
 3. **Click "Save"**
@@ -195,7 +195,7 @@
 ### Issue: "Invalid API key"
 **Solution:** Make sure you copied the full key:
 ```
-3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11
+[REDACTED - do not commit API keys]
 ```
 
 ### Issue: "Network error"

--- a/docs/legacy/SESSION_SUMMARY.md
+++ b/docs/legacy/SESSION_SUMMARY.md
@@ -354,7 +354,7 @@ All issues are post-launch enhancements. No blockers for AppSource submission.
 - Plausible: https://plausible.io/excel.oilpriceapi.com
 
 **API Testing:**
-- Admin API Key: 3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11
+- Admin API Key: [REDACTED - do not commit API keys]
 - Test /users/me: `curl -H "Authorization: Token {key}" https://api.oilpriceapi.com/users/me`
 
 ---


### PR DESCRIPTION
## Summary
- Redact API-key-shaped values from legacy Excel documentation
- Keep the legacy testing instructions while replacing sensitive values with an explicit no-keys placeholder

## Verification
- Ran a repository scan for API-key-shaped tokens excluding generated/vendor artifacts; no matches remain

## Follow-up
Any key that was already committed to public history should be treated as compromised and revoked server-side.