### PR TITLE
chore(security): add API key literal lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Secret shape lint
+        run: npm run lint:secrets
+
       - name: Build
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "lint:secrets": "node scripts/lint-secret-shapes.js",
     "generate:icons": "node generate-icons.js",
     "legacy:generate-starter-workbook": "node scripts/generate-starter-workbook.js",
     "legacy:validate-starter-workbook": "node scripts/validate-starter-workbook.js",

--- a/scripts/lint-secret-shapes.js
+++ b/scripts/lint-secret-shapes.js
@@ -1,0 +1,78 @@
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+const trackedFiles = execFileSync("git", ["ls-files"], {
+  cwd: repoRoot,
+  encoding: "utf8",
+})
+  .split("\n")
+  .filter(Boolean);
+
+const scannedPrefixes = [
+  ".github/",
+  "docs/",
+  "src/",
+  "tests/",
+  "README",
+  "manifest.xml",
+  "package.json",
+];
+
+const skippedExtensions = new Set([
+  ".ico",
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".gif",
+  ".webp",
+  ".xlsx",
+  ".zip",
+]);
+
+const contextPattern =
+  /(?:authorization\s*:\s*(?:token|bearer)\s+|api[_ -]?key\s*(?:[:=]|is|`)?\s*|apikey\s*(?:[:=]|is|`)?\s*)([`'"]?)([A-Za-z0-9_-]{32,})\1/gi;
+
+const redactedPattern = /^(?:\[?redacted\b|do-not-commit|your[_-]?api[_-]?key|apiKey)$/i;
+
+const findings = [];
+
+for (const file of trackedFiles) {
+  if (!scannedPrefixes.some((prefix) => file.startsWith(prefix))) {
+    continue;
+  }
+
+  if (skippedExtensions.has(path.extname(file).toLowerCase())) {
+    continue;
+  }
+
+  const absolutePath = path.join(repoRoot, file);
+  const contents = fs.readFileSync(absolutePath, "utf8");
+
+  contents.split(/\r?\n/).forEach((line, index) => {
+    for (const match of line.matchAll(contextPattern)) {
+      const token = match[2];
+      if (redactedPattern.test(token)) {
+        continue;
+      }
+
+      findings.push({
+        file,
+        line: index + 1,
+        preview: `${token.slice(0, 4)}...${token.slice(-4)}`,
+      });
+    }
+  });
+}
+
+if (findings.length > 0) {
+  console.error("Secret-shaped API key literals found:");
+  for (const finding of findings) {
+    console.error(`${finding.file}:${finding.line} ${finding.preview}`);
+  }
+  process.exit(1);
+}
+
+console.log("No API-key-shaped literals found in scanned files.");


### PR DESCRIPTION
## Summary
- add a CI lint that scans docs/source/workflow text for API-key-shaped literals in API key or Authorization contexts
- wire the lint into the existing GitHub Actions test workflow before build/test

## Verification
- npm run lint:secrets
- npm run build
- npm test -- --runInBand

Refs OilpriceAPI/oilpriceapi-api#4608