### PR TITLE
Send Excel client attribution headers

### DIFF
--- a/public/taskpane.js
+++ b/public/taskpane.js
@@ -2,6 +2,7 @@
 
 const API_KEY_STORAGE = "oilpriceapi_key";
 const ADDIN_VERSION = "1.0.0";
+const CLIENT_MARKER = `oilpriceapi-excel/${ADDIN_VERSION}`;
 const TEST_URL =
   "https://api.oilpriceapi.com/v1/prices/latest?by_code=BRENT_CRUDE_USD";
 const TEST_ENDPOINT_LABEL = "/v1/prices/latest?by_code=BRENT_CRUDE_USD";
@@ -16,6 +17,14 @@ const diagnostics = {
   lastEndpoint: TEST_ENDPOINT_LABEL,
   lastTestAt: "",
 };
+
+function attributionHeaders() {
+  return {
+    "X-Api-Client": CLIENT_MARKER,
+    "X-Client-Version": ADDIN_VERSION,
+    "X-Excel-Addin-Version": ADDIN_VERSION,
+  };
+}
 
 Office.onReady((info) => {
   if (info.host !== Office.HostType.Excel) {
@@ -175,6 +184,7 @@ async function testConnection() {
       headers: {
         Authorization: `Token ${apiKey}`,
         "Content-Type": "application/json",
+        ...attributionHeaders(),
       },
     });
 

--- a/src/functions/functions.ts
+++ b/src/functions/functions.ts
@@ -9,6 +9,8 @@
 
 /// <reference types="@types/office-js" />
 
+import { oilpriceAttributionHeaders } from "../utils/client-attribution";
+
 declare const OfficeRuntime: {
   storage: {
     getItem(key: string): Promise<string | null>;
@@ -264,6 +266,7 @@ async function apiGet(path: string, query: string | undefined, apiKey: string): 
     headers: {
       Authorization: `Token ${apiKey}`,
       "Content-Type": "application/json",
+      ...oilpriceAttributionHeaders(),
     },
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   getHeatContent,
   CommodityType,
 } from "./utils/conversions";
+import { oilpriceAttributionHeaders } from "./utils/client-attribution";
 
 /**
  * Commodity code to commodity type mapping
@@ -109,6 +110,7 @@ async function fetchExchangeRates(
         headers: {
           Authorization: `Token ${apiKey}`,
           "Content-Type": "application/json",
+          ...oilpriceAttributionHeaders(),
         },
       },
     );

--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -7,6 +7,7 @@ import {
   UpgradeRequiredError,
   PLAN_FEATURES,
 } from "../types/user-tier";
+import { oilpriceAttributionHeaders } from "./client-attribution";
 
 const API_BASE_URL = "https://api.oilpriceapi.com/v1";
 
@@ -180,6 +181,14 @@ export class OilPriceAPIClient {
     this.apiKey = apiKey;
   }
 
+  private requestHeaders(): Record<string, string> {
+    return {
+      Authorization: `Token ${this.apiKey}`,
+      "Content-Type": "application/json",
+      ...oilpriceAttributionHeaders(),
+    };
+  }
+
   /**
    * Fetch a single price for a commodity code
    */
@@ -189,10 +198,7 @@ export class OilPriceAPIClient {
       console.log("[API] Fetching:", url);
 
       const response = await fetch(url, {
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: this.requestHeaders(),
       });
 
       console.log(
@@ -258,10 +264,7 @@ export class OilPriceAPIClient {
     try {
       const url = `${API_BASE_URL.replace("/v1", "")}/users/me`;
       const response = await fetch(url, {
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: this.requestHeaders(),
       });
 
       if (!response.ok) {
@@ -310,10 +313,7 @@ export class OilPriceAPIClient {
     try {
       const url = `${API_BASE_URL}/prices/all`;
       const response = await fetch(url, {
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: this.requestHeaders(),
       });
 
       if (!response.ok) {
@@ -360,10 +360,7 @@ export class OilPriceAPIClient {
 
       const url = `${API_BASE_URL}/prices/past_year?by_code=${code}`;
       const response = await fetch(url, {
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: this.requestHeaders(),
       });
 
       if (response.status === 403) {
@@ -432,10 +429,7 @@ export class OilPriceAPIClient {
 
       const url = `${API_BASE_URL}/prices/past_month?by_code=${code}`;
       const response = await fetch(url, {
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: this.requestHeaders(),
       });
 
       if (!response.ok) {
@@ -482,10 +476,7 @@ export class OilPriceAPIClient {
       console.log("[API] Fetching Data Connector:", url);
 
       const response = await fetch(url, {
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: this.requestHeaders(),
       });
 
       console.log(
@@ -528,10 +519,7 @@ export class OilPriceAPIClient {
     try {
       const url = `${API_BASE_URL}/webhooks`;
       const response = await fetch(url, {
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: this.requestHeaders(),
       });
 
       if (!response.ok) {
@@ -558,10 +546,7 @@ export class OilPriceAPIClient {
       const url = `${API_BASE_URL}/webhooks`;
       const response = await fetch(url, {
         method: "POST",
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: this.requestHeaders(),
         body: JSON.stringify(options),
       });
 
@@ -588,10 +573,7 @@ export class OilPriceAPIClient {
       const url = `${API_BASE_URL}/webhooks/${id}`;
       const response = await fetch(url, {
         method: "DELETE",
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: this.requestHeaders(),
       });
 
       if (!response.ok) {
@@ -614,10 +596,7 @@ export class OilPriceAPIClient {
       const url = `${API_BASE_URL}/webhooks/${id}/test`;
       const response = await fetch(url, {
         method: "POST",
-        headers: {
-          Authorization: `Token ${this.apiKey}`,
-          "Content-Type": "application/json",
-        },
+        headers: this.requestHeaders(),
       });
 
       if (!response.ok) {

--- a/src/utils/client-attribution.ts
+++ b/src/utils/client-attribution.ts
@@ -1,0 +1,10 @@
+export const OILPRICEAPI_EXCEL_VERSION = "1.0.0";
+export const OILPRICEAPI_EXCEL_CLIENT = `oilpriceapi-excel/${OILPRICEAPI_EXCEL_VERSION}`;
+
+export function oilpriceAttributionHeaders(): Record<string, string> {
+  return {
+    "X-Api-Client": OILPRICEAPI_EXCEL_CLIENT,
+    "X-Client-Version": OILPRICEAPI_EXCEL_VERSION,
+    "X-Excel-Addin-Version": OILPRICEAPI_EXCEL_VERSION,
+  };
+}

--- a/tests/unit/api-client.test.ts
+++ b/tests/unit/api-client.test.ts
@@ -3,6 +3,7 @@ import {
   PriceData,
   APIError,
 } from "../../src/utils/api-client";
+import { oilpriceAttributionHeaders } from "../../src/utils/client-attribution";
 
 // Mock fetch globally
 const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
@@ -11,6 +12,11 @@ const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
 describe("OilPriceAPIClient", () => {
   let client: OilPriceAPIClient;
   const mockApiKey = "test-api-key-12345";
+  const expectedHeaders = {
+    Authorization: `Token ${mockApiKey}`,
+    "Content-Type": "application/json",
+    ...oilpriceAttributionHeaders(),
+  };
 
   beforeEach(() => {
     client = new OilPriceAPIClient(mockApiKey);
@@ -58,10 +64,7 @@ describe("OilPriceAPIClient", () => {
       expect(mockFetch).toHaveBeenCalledWith(
         "https://api.oilpriceapi.com/v1/prices/latest?by_code=BRENT_CRUDE_USD",
         {
-          headers: {
-            Authorization: `Token ${mockApiKey}`,
-            "Content-Type": "application/json",
-          },
+          headers: expectedHeaders,
         },
       );
     });
@@ -940,10 +943,7 @@ describe("OilPriceAPIClient", () => {
       expect(mockFetch).toHaveBeenCalledWith(
         "https://api.oilpriceapi.com/v1/webhooks",
         {
-          headers: {
-            Authorization: `Token ${mockApiKey}`,
-            "Content-Type": "application/json",
-          },
+          headers: expectedHeaders,
         },
       );
     });
@@ -1042,10 +1042,7 @@ describe("OilPriceAPIClient", () => {
         "https://api.oilpriceapi.com/v1/webhooks",
         {
           method: "POST",
-          headers: {
-            Authorization: `Token ${mockApiKey}`,
-            "Content-Type": "application/json",
-          },
+          headers: expectedHeaders,
           body: JSON.stringify({
             url: "https://example.com/webhook",
             events: ["price.updated"],
@@ -1122,10 +1119,7 @@ describe("OilPriceAPIClient", () => {
         "https://api.oilpriceapi.com/v1/webhooks/wh_123",
         {
           method: "DELETE",
-          headers: {
-            Authorization: `Token ${mockApiKey}`,
-            "Content-Type": "application/json",
-          },
+          headers: expectedHeaders,
         },
       );
     });
@@ -1201,10 +1195,7 @@ describe("OilPriceAPIClient", () => {
         "https://api.oilpriceapi.com/v1/webhooks/wh_123/test",
         {
           method: "POST",
-          headers: {
-            Authorization: `Token ${mockApiKey}`,
-            "Content-Type": "application/json",
-          },
+          headers: expectedHeaders,
         },
       );
     });

--- a/tests/unit/functions.test.ts
+++ b/tests/unit/functions.test.ts
@@ -38,6 +38,9 @@ describe("OilPrice custom functions MVP", () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: "Token test-api-key-123",
+            "X-Api-Client": "oilpriceapi-excel/1.0.0",
+            "X-Client-Version": "1.0.0",
+            "X-Excel-Addin-Version": "1.0.0",
           }),
         }),
       );


### PR DESCRIPTION
## Summary
- add a shared Excel attribution-header helper for TypeScript API requests
- send X-Api-Client, X-Client-Version, and X-Excel-Addin-Version from custom functions, the workbook API client, exchange-rate fetches, and the direct taskpane test request
- update unit expectations so SDK attribution markers stay covered

Pairs with OilpriceAPI/oilpriceapi-api#4609 and supports OilpriceAPI/oilpriceapi-api#4607.

## Verification
- npm run scan:secrets
- npm test -- --runInBand (107 passed)
- npm run build
- npx office-addin-manifest validate manifest.xml
- npx office-addin-manifest validate dist/manifest.xml
- git diff --check