### PR TITLE
docs: 2-minute customer quickstart + one-click Windows installer

### DIFF
--- a/CUSTOMER_QUICKSTART.md
+++ b/CUSTOMER_QUICKSTART.md
@@ -1,0 +1,87 @@
+# OilPrice Excel Add-in — 2-Minute Setup
+
+Live oil, gas, and fuel prices in your spreadsheet, as a formula:
+
+```excel
+=OILPRICE.PRICE("BRENT_CRUDE_USD")
+```
+
+You need: an [OilPriceAPI account](https://www.oilpriceapi.com/auth/signup) and your API key (Dashboard → API Keys → Copy).
+
+Pick the option that matches how you use Excel. **Option 1 is the fastest and works on any computer.**
+
+---
+
+## Option 1 — Excel on the web (recommended, no install, ~2 minutes)
+
+1. Download the add-in file: **[manifest.xml](https://oilpriceapi.github.io/excel-energy-addin/manifest.xml)** (right-click → _Save link as…_ if it opens in the browser).
+2. Go to [office.com](https://www.office.com), sign in, and open your workbook in **Excel**.
+3. On the **Home** tab, click **Add-ins** → **More Add-ins**.
+4. Choose the **My Add-ins** tab → **Upload My Add-in** (top-left corner of the dialog).
+5. Browse to the `manifest.xml` you downloaded and click **Upload**.
+6. The **OilPrice** button appears on your ribbon. Click it, paste your API key in the task pane, click **Save Key**, then **Test Key**.
+7. In any cell, type:
+
+   ```excel
+   =OILPRICE.PRICE("BRENT_CRUDE_USD")
+   ```
+
+That's it. The formula recalculates on refresh, and you can point it at a cell: `=OILPRICE.PRICE(A1)`.
+
+---
+
+## Option 2 — Excel desktop on Windows
+
+Two ways, depending on your setup:
+
+### 2a. Your company uses Microsoft 365 (easiest for desktop)
+
+If you (or your IT admin) can open the Microsoft 365 admin center, this deploys the add-in properly to desktop Excel — no scripts, no registry:
+
+1. Go to [admin.microsoft.com](https://admin.microsoft.com) → **Settings** → **Integrated apps**.
+2. Click **Upload custom apps** → app type **Office Add-in**.
+3. Choose **Provide link to manifest file** and paste:
+
+   ```text
+   https://oilpriceapi.github.io/excel-energy-addin/manifest.xml
+   ```
+
+4. Assign it to yourself (or _Entire organization_), accept, and finish.
+5. Restart Excel. The **OilPrice** add-in appears automatically (allow up to a few hours the first time).
+
+### 2b. One-click script (personal machine, admin rights)
+
+1. Download **[install-windows.cmd](https://raw.githubusercontent.com/OilpriceAPI/excel-energy-addin/main/scripts/install-windows.cmd)** (right-click → _Save link as…_).
+2. Double-click it and choose **Yes** on the administrator prompt.
+3. When the window says it's done, restart Excel.
+4. In Excel: **Insert** → **My Add-ins** → **Shared Folder** tab → **OilPrice**.
+
+---
+
+## Option 3 — Excel desktop on Mac
+
+Paste this one line into Terminal, then restart Excel:
+
+```bash
+mkdir -p ~/Library/Containers/com.microsoft.Excel/Data/Documents/wef && curl -fsSL https://oilpriceapi.github.io/excel-energy-addin/manifest.xml -o ~/Library/Containers/com.microsoft.Excel/Data/Documents/wef/oilprice-manifest.xml
+```
+
+Then in Excel: **Insert** → **My Add-ins** → the **OilPrice** add-in is listed under Developer Add-ins.
+
+---
+
+## First formulas to try
+
+```excel
+=OILPRICE.PRICE("BRENT_CRUDE_USD")     ' latest Brent price
+=OILPRICE.PRICE("WTI_USD")             ' latest WTI price
+=OILPRICE.PRICE(A1)                    ' code from a cell — recalculates when A1 changes
+=OILPRICE.CODES()                      ' list every supported commodity code
+```
+
+## If something looks wrong
+
+- **The task pane is blank** → close Excel fully and reopen; on the web, remove and re-upload the manifest.
+- **`#VALUE!` from every formula** → you may have an old manifest cached. Re-download `manifest.xml` (fixes shipped recently) and repeat the upload step.
+- **Where's my API key?** → [Dashboard → API Keys](https://www.oilpriceapi.com/dashboard).
+- Stuck? Email [support@oilpriceapi.com](mailto:support@oilpriceapi.com) — a human reads it.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 This repository contains the OilPrice Excel add-in for refreshable OilPriceAPI formulas.
 
+**Installing it?** See the **[2-minute customer quickstart](CUSTOMER_QUICKSTART.md)** — Excel on the web (no install), Windows desktop (one-click script or Microsoft 365 admin deploy), and Mac (one Terminal line).
+
 The customer-facing Excel path is the add-in. Other spreadsheet setup variants are not the current support path.
 
 ## MVP Scope

--- a/scripts/install-windows.cmd
+++ b/scripts/install-windows.cmd
@@ -1,0 +1,23 @@
+@echo off
+REM OilPrice Excel Add-in - one-click Windows desktop setup.
+REM Downloads the official setup script from this repository and runs it
+REM with administrator rights (needed once, to register the add-in catalog).
+
+setlocal
+set "PS1_URL=https://raw.githubusercontent.com/OilpriceAPI/excel-energy-addin/main/scripts/setup-windows-desktop-sideload.ps1"
+set "PS1_PATH=%TEMP%\oilprice-addin-setup.ps1"
+
+echo Downloading the OilPrice add-in setup script...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri '%PS1_URL%' -OutFile '%PS1_PATH%'"
+if not exist "%PS1_PATH%" (
+  echo Download failed. Check your internet connection and try again.
+  pause
+  exit /b 1
+)
+
+echo Requesting administrator approval (choose Yes on the prompt)...
+powershell -NoProfile -Command "Start-Process powershell -Verb RunAs -Wait -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','%PS1_PATH%','-ClearOfficeCache'"
+
+echo.
+echo Done. Restart Excel, then go to: Insert ^> My Add-ins ^> Shared Folder ^> OilPrice.
+pause


### PR DESCRIPTION
Makes sideloading dirt-simple for warm leads (api#4239, József) while AppSource approval is pending.

- **CUSTOMER_QUICKSTART.md** — customer-voice, 3 paths ranked by simplicity: Excel-web upload (~2 min, no install, any OS) → Windows desktop via M365 Integrated Apps (no scripts) or a one-click self-elevating `install-windows.cmd` → Mac one-liner into the `wef` folder.
- **scripts/install-windows.cmd** — downloads the existing setup ps1 and runs it elevated; turns the current 'open PowerShell as Administrator' instruction into double-click + Yes.
- README links the quickstart.

No claims-policy violations: no AppSource/store promises, no Power Query/WEBSERVICE instructions in public copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a customer quickstart guide with setup instructions for Excel on the web, Windows, and Mac.
  * Added example formulas and troubleshooting guidance, including API key location and support details.
  * Added a one-click Windows installer to simplify desktop add-in setup.

* **Documentation**
  * Updated the README with a link to the new two-minute customer quickstart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->