### PR TITLE
fix: add structured Excel endpoint families

### DIFF
--- a/CUSTOMER_QUICKSTART.md
+++ b/CUSTOMER_QUICKSTART.md
@@ -27,6 +27,19 @@ Start with these formulas:
 
 `PRICE` is numeric. `INFO` supplies the API-returned unit, source, source timestamp, and freshness fields needed to interpret that number. Refresh timing is controlled by Excel recalculation and API availability; data cadence varies by source, market hours, dataset, and account entitlement.
 
+For structured datasets, use the allowlisted `GET` helper:
+
+```excel
+=OILPRICE.GET("/v1/ei/oil_inventories/latest")
+=OILPRICE.GET("/v1/storage/cushing")
+=OILPRICE.GET("/v1/bunker-fuels/all")
+=OILPRICE.GET("/v1/ei/well-permits/preview")
+```
+
+Nested API fields become dot-named worksheet fields or columns, so values
+remain usable in formulas and charts rather than appearing as JSON blobs.
+Access to each dataset depends on the API key's current entitlements.
+
 ## Recovery
 
 - `#AUTH_REQUIRED` or `#AUTH_INVALID`: open the OilPrice pane and save a current key.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,33 @@ An OilPriceAPI account and API key are required. Dataset access, endpoint access
 
 `PRICE` intentionally returns a bare number for spreadsheet calculations. Use `INFO`, `STATUS`, or `UNIT` when the source context matters.
 
+## Supported endpoint families
+
+`OILPRICE.GET` uses an explicit read-only allowlist. In addition to spot and
+futures prices, it supports these production endpoint families:
+
+| Family | Example |
+| --- | --- |
+| EIA WPSR inventories | `=OILPRICE.GET("/v1/ei/oil_inventories/latest")` |
+| OPEC production | `=OILPRICE.GET("/v1/ei/opec_productions/latest")` |
+| Rig counts | `=OILPRICE.GET("/v1/rig-counts/latest")` |
+| Storage | `=OILPRICE.GET("/v1/storage/cushing")` |
+| Marine bunker fuels | `=OILPRICE.GET("/v1/bunker-fuels/all")` |
+| Well production | `=OILPRICE.GET("/v1/well-production/summary")` |
+| Well permits | `=OILPRICE.GET("/v1/ei/well-permits/preview")` |
+| Drilling intelligence | `=OILPRICE.GET("/v1/drilling-intelligence/summary")` |
+| Account analytics | `=OILPRICE.GET("/v1/analytics/statistics", "code=BRENT_CRUDE_USD&period=30d")` |
+
+Nested records spill into dot-named columns such as `operator.name` and
+`freshness.status`; nested summaries spill into dot-named field rows. This
+keeps worksheet cells numeric and avoids JSON blobs. Multi-code latest-price
+responses append a visible `MISSING CODES` row when the API omits a requested
+code. A null latest price returns `#NO_DATA` rather than a misleading zero or a
+malformed-response label.
+
+Endpoint access and returned data remain account-dependent. `GET` rejects
+paths outside the allowlist and rejects credentials in query strings.
+
 ## Distribution Status
 
 - Mac Excel 16.110.2 on macOS passed the sideload, authentication, formula, recalculation, and secret-free diagnostics smoke on 2026-07-03.

--- a/src/functions/functions.ts
+++ b/src/functions/functions.ts
@@ -107,6 +107,69 @@ const ENDPOINT_CATALOG: EndpointCatalogEntry[] = [
     description: "Diesel prices",
   },
   {
+    id: "rig-counts",
+    path: "/v1/rig-counts/{view}",
+    pattern:
+      /^\/v1\/rig-counts(\/(latest|current|historical|trends|summary))?$/,
+    description: "Baker Hughes rig counts",
+  },
+  {
+    id: "storage",
+    path: "/v1/storage/{view}",
+    pattern:
+      /^\/v1\/storage(\/(cushing|spr|regional|history\/[A-Za-z0-9_.-]+))?$/,
+    description: "Cushing, SPR, and regional storage",
+  },
+  {
+    id: "ei-oil-inventories",
+    path: "/v1/ei/oil_inventories/{view}",
+    pattern:
+      /^\/v1\/ei\/oil_inventories(\/(latest|summary|by_product|historical|cushing|[A-Za-z0-9_.-]+))?$/,
+    description: "EIA WPSR oil inventories",
+  },
+  {
+    id: "ei-opec-production",
+    path: "/v1/ei/opec_productions/{view}",
+    pattern:
+      /^\/v1\/ei\/opec_productions(\/(latest|total|by_country|historical|top_producers|[A-Za-z0-9_.-]+))?$/,
+    description: "OPEC production",
+  },
+  {
+    id: "bunker-fuels",
+    path: "/v1/bunker-fuels/{view}",
+    pattern:
+      /^\/v1\/bunker-fuels\/(all|compare|spreads\/ports|ports\/[A-Z]{3,5}|historical\/[A-Z]{3,5})$/,
+    description: "Marine bunker fuels and ports",
+  },
+  {
+    id: "well-production",
+    path: "/v1/well-production/{view}",
+    pattern:
+      /^\/v1\/well-production\/(summary|states|states\/[A-Z]{2}|pru\/[A-Za-z0-9_.-]+|wells\/[A-Za-z0-9_.-]+|top-producers|cycle-time|cycle-time\/cohorts)$/,
+    description: "Well production",
+  },
+  {
+    id: "ei-well-permits",
+    path: "/v1/ei/well-permits/{view}",
+    pattern:
+      /^\/v1\/ei\/well-permits(\/(preview|states|states\/[A-Z]{2}|latest|summary|by-state|by-operator|by-formation|search|[A-Za-z0-9_.-]+))?$/,
+    description: "Well permits",
+  },
+  {
+    id: "drilling-intelligence",
+    path: "/v1/drilling-intelligence/{view}",
+    pattern:
+      /^\/v1\/drilling-intelligence(\/(latest|summary|trends|frac-spreads|well-permits|duc-wells|completions|wells-drilled|basin\/[A-Za-z0-9_.%-]+))?$/,
+    description: "Drilling intelligence",
+  },
+  {
+    id: "analytics",
+    path: "/v1/analytics/{view}",
+    pattern:
+      /^\/v1\/analytics\/(performance|statistics|correlation|trend|spread|forecast)$/,
+    description: "Account analytics",
+  },
+  {
     id: "futures",
     path: "/v1/futures/{family}",
     pattern:
@@ -486,6 +549,42 @@ function valueToCell(value: unknown): Cell {
   return JSON.stringify(value);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Flatten nested response context into dot-addressable worksheet fields.
+ * Arrays of records are represented by a count here; a primary collection is
+ * rendered separately by primaryCollectionToTable.
+ */
+function flattenRecord(
+  value: Record<string, unknown>,
+  prefix = "",
+  target: Record<string, unknown> = {},
+): Record<string, unknown> {
+  Object.entries(value).forEach(([key, entry]) => {
+    const field = prefix ? `${prefix}.${key}` : key;
+    if (isRecord(entry)) {
+      flattenRecord(entry, field, target);
+      return;
+    }
+    if (Array.isArray(entry)) {
+      const scalarOnly = entry.every(
+        (item) =>
+          item === null ||
+          ["string", "number", "boolean"].includes(typeof item),
+      );
+      target[field] = scalarOnly
+        ? entry.map((item) => valueToCell(item)).join(", ")
+        : entry.length;
+      return;
+    }
+    target[field] = entry;
+  });
+  return target;
+}
+
 /**
  * Renders one worksheet cell for a named field. Numbers and booleans are kept
  * unwrapped so Excel does not coerce them to text. Numeric-looking STRING
@@ -503,11 +602,33 @@ function cellFor(field: string, value: unknown): Cell {
 }
 
 function objectToTable(value: Record<string, unknown>): Table {
-  const rows: Table = Object.entries(value).map(([key, entry]) => [
+  const rows: Table = Object.entries(flattenRecord(value)).map(([key, entry]) => [
     key,
     cellFor(key, entry),
   ]);
   return [["Field", "Value"], ...rows];
+}
+
+function recordsToTable(records: Array<Record<string, unknown>>): Table {
+  if (records.length === 0) return tableError("NO_DATA", "No data returned");
+
+  const headers: string[] = [];
+  const seen = new Set<string>();
+  records.forEach((record) => {
+    Object.keys(record).forEach((key) => {
+      if (!seen.has(key)) {
+        seen.add(key);
+        headers.push(key);
+      }
+    });
+  });
+
+  return [
+    headers,
+    ...records.map((record) =>
+      headers.map((header) => cellFor(header, record[header])),
+    ),
+  ];
 }
 
 function arrayToTable(data: unknown[]): Table {
@@ -516,11 +637,88 @@ function arrayToTable(data: unknown[]): Table {
     return [["Value"], ...data.map((entry) => [valueToCell(entry)])];
   }
 
-  const headers = Object.keys(data[0]);
-  const rows: Table = data.map((entry: any) =>
-    headers.map((header) => cellFor(header, entry[header])),
+  return recordsToTable(
+    data.map((entry) => flattenRecord(entry as Record<string, unknown>)),
   );
-  return [headers, ...rows];
+}
+
+function selectRecordEntries(
+  value: Record<string, unknown>,
+  include: (key: string, entry: unknown) => boolean,
+): Record<string, unknown> {
+  const selected: Record<string, unknown> = {};
+  Object.entries(value).forEach(([key, entry]) => {
+    if (include(key, entry)) selected[key] = entry;
+  });
+  return selected;
+}
+
+function primaryCollectionToTable(
+  data: Record<string, unknown>,
+): Table | undefined {
+  const preferredCollections = [
+    "inventories",
+    "countries",
+    "well_permits",
+    "top_states",
+    "data_sources",
+  ];
+  const candidates = Object.entries(data)
+    .filter(
+      ([, value]) =>
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.every((entry) => isRecord(entry)),
+    )
+    .sort(([leftKey, left], [rightKey, right]) => {
+      const leftPriority = preferredCollections.indexOf(leftKey);
+      const rightPriority = preferredCollections.indexOf(rightKey);
+      if (leftPriority !== -1 || rightPriority !== -1) {
+        if (leftPriority === -1) return 1;
+        if (rightPriority === -1) return -1;
+        return leftPriority - rightPriority;
+      }
+      return (right as unknown[]).length - (left as unknown[]).length;
+    });
+
+  if (candidates.length === 0) return undefined;
+
+  const [collectionKey, collection] = candidates[0] as [
+    string,
+    Array<Record<string, unknown>>,
+  ];
+  const contextSource = selectRecordEntries(
+    data,
+    (key, value) => key !== collectionKey && !Array.isArray(value),
+  );
+  const context = flattenRecord(contextSource, "context");
+  return recordsToTable(
+    collection.map((record) => ({
+      ...flattenRecord(record),
+      ...context,
+    })),
+  );
+}
+
+function bunkerPortsToTable(
+  ports: Record<string, unknown>,
+): Table | undefined {
+  const records: Array<Record<string, unknown>> = [];
+  Object.entries(ports).forEach(([portCode, rawPort]) => {
+    if (!isRecord(rawPort) || !Array.isArray(rawPort.prices)) return;
+    const port = isRecord(rawPort.port)
+      ? flattenRecord(rawPort.port, "port")
+      : { "port.code": portCode };
+    rawPort.prices.forEach((rawPrice) => {
+      if (isRecord(rawPrice)) {
+        records.push({
+          ...port,
+          ...flattenRecord(rawPrice),
+        });
+      }
+    });
+  });
+  return records.length > 0 ? recordsToTable(records) : undefined;
 }
 
 function pricesHashToTable(prices: Record<string, unknown>): Table {
@@ -660,6 +858,20 @@ function responseToTable(payload: any): Table {
 
   let data = payload?.data;
 
+  // Status and analytics endpoints return useful fields at the root.
+  if ((data === undefined || data === null) && isRecord(payload)) {
+    const rootData = selectRecordEntries(
+      payload,
+      (key) => key !== "data",
+    );
+    const meaningfulKeys = Object.keys(rootData).filter(
+      (key) => key !== "status",
+    );
+    if (meaningfulKeys.length > 0 || !("data" in payload)) {
+      data = rootData;
+    }
+  }
+
   // #54: /prices/all and /prices/all/health double-wrap in data.data.
   if (
     data &&
@@ -695,7 +907,15 @@ function responseToTable(payload: any): Table {
     }
 
     if (Array.isArray(data.prices)) {
-      return arrayToTable(data.prices);
+      const table = arrayToTable(data.prices);
+      if (Array.isArray(data.missing) && data.missing.length > 0) {
+        const codes = data.missing
+          .map((code: unknown) => String(code))
+          .filter(Boolean)
+          .join(", ");
+        return appendNoteRow(table, `MISSING CODES: ${codes}`);
+      }
+      return table;
     }
 
     if (
@@ -719,6 +939,14 @@ function responseToTable(payload: any): Table {
         ]),
       ];
     }
+
+    if (isRecord(data.ports)) {
+      const bunkerTable = bunkerPortsToTable(data.ports);
+      if (bunkerTable) return bunkerTable;
+    }
+
+    const collectionTable = primaryCollectionToTable(data);
+    if (collectionTable) return collectionTable;
 
     return objectToTable(data);
   }
@@ -795,6 +1023,9 @@ export async function oilpricePrice(code: string): Promise<number | string> {
       );
     }
     const price = data.price;
+    if (price === null || price === undefined) {
+      return cellError("NO_DATA", "No numeric price returned");
+    }
     if (typeof price !== "number") {
       return cellError("INVALID_RESPONSE", "API returned a malformed price");
     }

--- a/tests/fixtures/api/endpoint-families.json
+++ b/tests/fixtures/api/endpoint-families.json
@@ -1,0 +1,248 @@
+{
+  "rig_counts": {
+    "status": "success",
+    "data": {
+      "code": "US_RIG_COUNT",
+      "count": 588,
+      "region": "United States",
+      "unit": "rigs",
+      "source": "Baker Hughes",
+      "created_at": "2026-07-24T00:00:00Z"
+    }
+  },
+  "storage": {
+    "status": "success",
+    "data": {
+      "storage": {
+        "current": {
+          "value": 20.04,
+          "units": "million_barrels",
+          "capacity_utilization": "32.86",
+          "data_date": "2026-07-10T00:00:00.000Z"
+        },
+        "analytics": {
+          "trend": "building",
+          "market_signal": "neutral"
+        },
+        "metadata": {
+          "source": "EIA",
+          "update_frequency": "weekly"
+        }
+      }
+    }
+  },
+  "oil_inventories": {
+    "data": {
+      "report_date": "2026-07-22",
+      "week_ending": "2026-07-17",
+      "source": "EIA Weekly Petroleum Status Report",
+      "inventories": [
+        {
+          "product": "crude_commercial",
+          "location": "total",
+          "name": "Crude Oil Commercial Stocks",
+          "volume_mmbbl": 411.68,
+          "week_over_week": 2.01,
+          "build_draw": "build"
+        },
+        {
+          "product": "crude_spr",
+          "location": "spr",
+          "name": "Strategic Petroleum Reserve",
+          "volume_mmbbl": 311.45,
+          "week_over_week": -5.057,
+          "build_draw": "draw"
+        }
+      ]
+    },
+    "meta": {
+      "source": "EIA WPSR"
+    }
+  },
+  "opec": {
+    "data": {
+      "report_month": "2026-05-01",
+      "source": "OPEC Monthly Oil Market Report",
+      "opec_total": 18.983,
+      "countries": [
+        {
+          "country": "saudi_arabia",
+          "name": "Saudi Arabia",
+          "production_mbpd": 6.768
+        },
+        {
+          "country": "iran",
+          "name": "Iran",
+          "production_mbpd": 2.854
+        }
+      ]
+    }
+  },
+  "bunker_fuels": {
+    "status": "success",
+    "data": {
+      "ports": {
+        "SIN": {
+          "port": {
+            "code": "SIN",
+            "name": "Singapore",
+            "country": "Singapore"
+          },
+          "prices": [
+            {
+              "grade": "HFO",
+              "price": 634.5,
+              "currency": "USD",
+              "unit": "MT",
+              "stale": false
+            },
+            {
+              "grade": "VLSFO",
+              "price": 869,
+              "currency": "USD",
+              "unit": "MT",
+              "stale": false
+            }
+          ]
+        },
+        "RTM": {
+          "port": {
+            "code": "RTM",
+            "name": "Rotterdam",
+            "country": "Netherlands"
+          },
+          "prices": [
+            {
+              "grade": "MGO",
+              "price": 1198.25,
+              "currency": "USD",
+              "unit": "MT",
+              "stale": false
+            }
+          ]
+        }
+      },
+      "metadata": {
+        "port_count": 2,
+        "currency": "USD",
+        "unit": "MT"
+      }
+    }
+  },
+  "well_production": {
+    "status": "success",
+    "data": {
+      "national": {
+        "period": "2026-07",
+        "oil_bbl": 0,
+        "gas_mcf": 0
+      },
+      "coverage": {
+        "latest_period": "2026-07",
+        "coverage_stale": false
+      },
+      "top_states": [
+        {
+          "state": "TX",
+          "period": "2026-04",
+          "oil_bbl": 174743000,
+          "oil_bpd": 5824767,
+          "gas_mcf": 1164406000,
+          "boe": 368810667
+        },
+        {
+          "state": "NM",
+          "period": "2026-04",
+          "oil_bbl": 70985000,
+          "oil_bpd": 2366167,
+          "gas_mcf": 359485000,
+          "boe": 130899167
+        }
+      ]
+    }
+  },
+  "well_permits": {
+    "status": "success",
+    "data": {
+      "meta": {
+        "state": "TX",
+        "count": 2,
+        "bounded": true
+      },
+      "preview": true,
+      "well_permits": [
+        {
+          "api_number": "42365390430000",
+          "state_code": "TX",
+          "county": "Tatum",
+          "permit_date": "2026-07-08",
+          "operator": {
+            "name": "R. LACY SERVICES, LTD.",
+            "number": "687208"
+          },
+          "well": {
+            "name": "TERLINGUA A HV C",
+            "number": "3HH",
+            "type": "oil"
+          },
+          "provenance": {
+            "source": "texas_rrc",
+            "fetched_at": "2026-07-09T21:23:24.082Z"
+          }
+        },
+        {
+          "api_number": "42365390420000",
+          "state_code": "TX",
+          "county": "Tatum",
+          "permit_date": "2026-07-08",
+          "operator": {
+            "name": "R. LACY SERVICES, LTD.",
+            "number": "687208"
+          },
+          "well": {
+            "name": "TERLINGUA A HV A",
+            "number": "1HH",
+            "type": "oil"
+          },
+          "provenance": {
+            "source": "texas_rrc",
+            "fetched_at": "2026-07-09T21:23:24.082Z"
+          }
+        }
+      ]
+    }
+  },
+  "drilling": {
+    "status": "success",
+    "data": {
+      "rig_counts": {
+        "US_RIG_COUNT": 588,
+        "CANADA_RIG_COUNT": 204
+      },
+      "frac_spread_count": 196,
+      "well_permits": {
+        "last_30d": 714,
+        "by_state": {
+          "TX": 375,
+          "CO": 130
+        }
+      },
+      "duc_wells_total": 2446,
+      "deltas": {
+        "rig_counts": 32,
+        "well_permits": -559
+      },
+      "last_updated": "2026-07-24T19:07:27.871Z"
+    }
+  },
+  "analytics": {
+    "code": "BRENT_CRUDE_USD",
+    "period": 30,
+    "statistics": {
+      "z_score": 2.02,
+      "percentile": 95.8,
+      "volatility": 3.97
+    },
+    "tier": "free"
+  }
+}

--- a/tests/unit/functions-endpoint-families.test.ts
+++ b/tests/unit/functions-endpoint-families.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Production-shaped endpoint-family and renderer regression coverage (#57/#59).
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const mockStorage = {
+  getItem: jest.fn().mockResolvedValue("test-api-key-123"),
+  setItem: jest.fn().mockResolvedValue(undefined),
+};
+
+(globalThis as any).OfficeRuntime = { storage: mockStorage };
+(globalThis as any).fetch = jest.fn();
+(globalThis as any).CustomFunctions = { associate: jest.fn() } as any;
+
+import {
+  oilpriceGet,
+  oilpricePrice,
+} from "../../src/functions/functions";
+
+const fixture = JSON.parse(
+  fs.readFileSync(
+    path.join(
+      __dirname,
+      "..",
+      "fixtures",
+      "api",
+      "endpoint-families.json",
+    ),
+    "utf8",
+  ),
+);
+
+function mockFetchOnce(body: unknown): void {
+  ((globalThis as any).fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    headers: new Headers({ "x-request-id": "fixture" }),
+    json: async () => body,
+  });
+}
+
+function hasBlobCell(table: unknown[][]): boolean {
+  return table.some((row) =>
+    row.some(
+      (cell) =>
+        typeof cell === "string" &&
+        (cell.includes('{"') ||
+          cell.includes('":') ||
+          cell.includes("[object Object]")),
+    ),
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStorage.getItem.mockResolvedValue("test-api-key-123");
+});
+
+describe("#57 endpoint families", () => {
+  const cases = [
+    ["/v1/rig-counts/latest", "rig_counts"],
+    ["/v1/storage/cushing", "storage"],
+    ["/v1/ei/oil_inventories/latest", "oil_inventories"],
+    ["/v1/ei/opec_productions/latest", "opec"],
+    ["/v1/bunker-fuels/all", "bunker_fuels"],
+    ["/v1/well-production/summary", "well_production"],
+    ["/v1/ei/well-permits/preview", "well_permits"],
+    ["/v1/drilling-intelligence/summary", "drilling"],
+    ["/v1/analytics/statistics", "analytics"],
+  ] as const;
+
+  it.each(cases)("allows and renders %s without JSON blobs", async (endpoint, key) => {
+    mockFetchOnce(fixture[key]);
+
+    const table = await oilpriceGet(endpoint);
+
+    expect(table[0][0]).not.toContain("#");
+    expect(table.length).toBeGreaterThan(1);
+    expect(hasBlobCell(table)).toBe(false);
+    expect((globalThis as any).fetch).toHaveBeenCalledWith(
+      `https://api.oilpriceapi.com${endpoint}`,
+      expect.any(Object),
+    );
+  });
+
+  it("renders EI inventory rows with report context", async () => {
+    mockFetchOnce(fixture.oil_inventories);
+
+    const table = await oilpriceGet("/v1/ei/oil_inventories/latest");
+    const header = table[0];
+
+    expect(header).toContain("product");
+    expect(header).toContain("volume_mmbbl");
+    expect(header).toContain("context.report_date");
+    expect(table[1][header.indexOf("volume_mmbbl")]).toBe(411.68);
+    expect(table[1][header.indexOf("context.report_date")]).toBe("2026-07-22");
+  });
+
+  it("renders OPEC countries as numeric production rows", async () => {
+    mockFetchOnce(fixture.opec);
+
+    const table = await oilpriceGet("/v1/ei/opec_productions/latest");
+    const header = table[0];
+
+    expect(header).toContain("country");
+    expect(header).toContain("production_mbpd");
+    expect(header).toContain("context.opec_total");
+    expect(table[1][header.indexOf("production_mbpd")]).toBe(6.768);
+  });
+
+  it("flattens bunker ports and grades to one row per port-grade", async () => {
+    mockFetchOnce(fixture.bunker_fuels);
+
+    const table = await oilpriceGet("/v1/bunker-fuels/all");
+    const header = table[0];
+
+    expect(table).toHaveLength(4);
+    expect(header).toContain("port.code");
+    expect(header).toContain("grade");
+    expect(header).toContain("price");
+    expect(table[1][header.indexOf("port.code")]).toBe("SIN");
+    expect(typeof table[1][header.indexOf("price")]).toBe("number");
+  });
+
+  it("flattens permit operator, well, and provenance context", async () => {
+    mockFetchOnce(fixture.well_permits);
+
+    const table = await oilpriceGet("/v1/ei/well-permits/preview");
+    const header = table[0];
+
+    expect(header).toContain("operator.name");
+    expect(header).toContain("well.name");
+    expect(header).toContain("provenance.source");
+    expect(header).toContain("context.meta.bounded");
+    expect(table[1][header.indexOf("operator.name")]).toBe(
+      "R. LACY SERVICES, LTD.",
+    );
+  });
+
+  it("flattens nested summary and root-level analytics objects", async () => {
+    mockFetchOnce(fixture.drilling);
+    const drilling = await oilpriceGet("/v1/drilling-intelligence/summary");
+    expect(drilling).toContainEqual(["rig_counts.US_RIG_COUNT", 588]);
+    expect(drilling).toContainEqual(["well_permits.by_state.TX", 375]);
+
+    mockFetchOnce(fixture.analytics);
+    const analytics = await oilpriceGet(
+      "/v1/analytics/statistics",
+      "code=BRENT_CRUDE_USD&period=30d",
+    );
+    expect(analytics).toContainEqual(["statistics.z_score", 2.02]);
+    expect(analytics).toContainEqual(["statistics.percentile", 95.8]);
+  });
+});
+
+describe("#59 response polish", () => {
+  it("flattens multi-code freshness/changes and surfaces missing codes", async () => {
+    const multi = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          __dirname,
+          "..",
+          "fixtures",
+          "api",
+          "prices-latest-multi.json",
+        ),
+        "utf8",
+      ),
+    );
+    multi.data.missing = ["INVALID_CODE"];
+    mockFetchOnce(multi);
+
+    const table = await oilpriceGet(
+      "/v1/prices/latest",
+      "by_code=BRENT_CRUDE_USD,WTI_USD,INVALID_CODE",
+    );
+    const header = table[0];
+
+    expect(header).toContain("freshness.status");
+    expect(header).toContain("changes.24h.amount");
+    expect(hasBlobCell(table)).toBe(false);
+    expect(table[table.length - 1][0]).toContain(
+      "MISSING CODES: INVALID_CODE",
+    );
+  });
+
+  it("renders root status and nested category maps as readable fields", async () => {
+    mockFetchOnce({ status: "operational", version: "v1" });
+    await expect(oilpriceGet("/v1/status")).resolves.toContainEqual([
+      "status",
+      "operational",
+    ]);
+
+    mockFetchOnce({
+      status: "success",
+      data: { categories: { oil: 12, natural_gas: 8 } },
+    });
+    await expect(
+      oilpriceGet("/v1/commodities/categories"),
+    ).resolves.toContainEqual(["categories.oil", 12]);
+  });
+
+  it("returns NO_DATA rather than malformed response for a null price", async () => {
+    mockFetchOnce({
+      status: "success",
+      data: {
+        code: "URANIUM_USD",
+        price: null,
+        currency: "USD",
+        unit: "pound",
+      },
+    });
+
+    await expect(oilpricePrice("URANIUM_USD")).resolves.toBe(
+      "#NO_DATA: No numeric price returned",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- allow the requested read-only EIA/WPSR, OPEC, rig, storage, marine, permit, drilling, production, and analytics endpoint families
- render nested production responses as rectangular, dot-named worksheet fields instead of JSON blobs
- surface missing multi-code results and return `#NO_DATA` for null prices
- document supported families and add minimized production-shaped regression fixtures

## Verification
- `npx tsc --noEmit`
- `npm test -- --runInBand` (99 passed; 89.18% statements)
- `npm run scan:secrets`
- `npm run validate:claims` (29 surfaces)
- `npm run build`
- `npx office-addin-manifest validate manifest.xml`
- `git diff --check`

Closes #51
Closes #57
Closes #59

No package release. Merging may run the repository GitHub Pages workflow authorized for this sprint.