### PR TITLE
fix: send X-API-Client so the Excel add-in is attributable (#6167)

### DIFF
--- a/src/functions/functions.ts
+++ b/src/functions/functions.ts
@@ -17,6 +17,10 @@ import {
   RuntimeDiagnostic,
 } from "../utils/runtime-diagnostics";
 
+// #6167 — sent as X-Excel-Addin-Version so the server can attribute
+// this add-in (MinimalAnalyticsService maps it to client_type sdk-excel).
+const ADDIN_VERSION = "1.1.0";
+
 declare const OfficeRuntime: {
   storage: {
     getItem(key: string): Promise<string | null>;
@@ -421,6 +425,10 @@ async function apiGet(
         headers: {
           Authorization: `Token ${apiKey}`,
           "Content-Type": "application/json",
+          // See taskpane.ts — Office.js locks User-Agent; X-API-Client is how
+          // the server classifies this add-in. (#6167)
+          "X-API-Client": "oilpriceapi-excel",
+          "X-Excel-Addin-Version": ADDIN_VERSION,
         },
         signal: controller.signal,
       });

--- a/src/taskpane/taskpane.ts
+++ b/src/taskpane/taskpane.ts
@@ -12,6 +12,10 @@ import {
   requestIdFromResponse,
 } from "../utils/runtime-diagnostics";
 
+// #6167 — sent as X-Excel-Addin-Version so the server can attribute
+// this add-in (MinimalAnalyticsService maps it to client_type sdk-excel).
+const ADDIN_VERSION = "1.1.0";
+
 declare const OfficeRuntime: {
   storage: {
     getItem(key: string): Promise<string | null>;
@@ -331,6 +335,13 @@ async function testConnection(): Promise<void> {
       headers: {
         Authorization: `Token ${apiKey}`,
         "Content-Type": "application/json",
+        // Office.js locks User-Agent, so the server's client classifier is fed
+        // via X-API-Client (MinimalAnalyticsService.explicit_client_marker, which
+        // maps oilpriceapi-excel -> client_type 'sdk-excel'). Without it every
+        // call from this add-in records as client_type 'unknown' and the add-in
+        // is invisible in adoption reporting. (#6167)
+        "X-API-Client": "oilpriceapi-excel",
+        "X-Excel-Addin-Version": ADDIN_VERSION,
       },
       signal: controller.signal,
     });


### PR DESCRIPTION
Office.js locks `User-Agent`, so every fetch from this add-in recorded as `api_requests.client_type = 'unknown'` — invisible in adoption reporting.

The server already handles this: `MinimalAnalyticsService.explicit_client_marker` reads `X-API-Client` **and** `X-Excel-Addin-Version`, and maps `oilpriceapi-excel` → `sdk-excel`. **No server change needed.**

Both call sites patched — `taskpane.ts` and `functions.ts` are the only two fetches to `api.oilpriceapi.com` in the repo. Typechecks clean (remaining `TS2688` for jest/node types is the worktree lacking `node_modules`, not this change).

**Verify after deploy:**
```sql
select client_type, count(*), count(distinct user_id)
from api_requests
where created_at > now() - interval '1 day' and client_type = 'sdk-excel'
group by 1;
```

Related: OilpriceAPI/oilpriceapi-api#6167 · #6204 (adoption reporting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added version information to API requests.
  * Improved request identification for standard API calls and connection tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->