### PR TITLE
fix: make Excel request failures recoverable

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=moderate
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=moderate
+
       - name: Scan for committed secrets
         run: npm run scan:secrets
 

--- a/ADDIN_ACTIVATION_CHECKLIST.md
+++ b/ADDIN_ACTIVATION_CHECKLIST.md
@@ -22,7 +22,7 @@ Run this with a non-customer test API key. Do not paste the key in logs, screens
 6. Enter `=OILPRICE.PRICE("BRENT_CRUDE_USD")` and confirm it returns a numeric production value for a valid key.
 7. Put `BRENT_CRUDE_USD` in a worksheet cell, enter `=OILPRICE.PRICE(A1)`, then change the symbol cell and confirm the formula recalculates.
 8. Enter `=OILPRICE.GET("/v1/prices/latest","by_code=BRENT_CRUDE_USD")` and confirm it spills a readable table or a plain worksheet error.
-9. Confirm production API logs show the expected add-in request for the non-customer test account and the browser request shape is limited to `authorization,content-type`.
+9. Confirm production API logs show the expected add-in request for the non-customer test account and the browser request shape is `authorization,content-type,x-api-client,x-excel-addin-version`.
 10. Confirm no formula shows `#NAME?` after reload, workbook save/reopen, and recalculation.
 
 ## Customer Instructions Gate

--- a/APPSOURCE_METADATA.md
+++ b/APPSOURCE_METADATA.md
@@ -2,7 +2,7 @@
 
 Status: internal submission candidate; not submitted and not available in AppSource.
 
-Reviewed against the [OilPriceAPI product-facts contract](https://api.oilpriceapi.com/product-facts.json) on 2026-07-19. Contract version `2026-07-18`, schema `1.0.0`.
+Recheck all mutable listing claims against the currently published typed [OilPriceAPI product-facts contract](https://api.oilpriceapi.com/product-facts.json) immediately before submission. Record the observed contract version in the submission receipt rather than hardcoding it in customer copy.
 
 ## Listing Copy
 
@@ -33,7 +33,7 @@ Mac Excel 16.110.2 on macOS passed preview sideload, key save/test, `PRICE`, `GE
 
 Before submission, attach:
 
-1. A release-candidate manifest validation receipt.
+1. The exact submitted manifest, its actual `<Version>`, source commit, build workflow run, and SHA-256 checksum, plus a manifest validation receipt. The source `manifest.xml` version is a semantic template; it is not proof of the cache-busted `dist/manifest.xml` version.
 2. Hosted asset HTTP checks for the exact release SHA.
 3. Screenshots from a smoke-proven platform with no API key or customer data.
 4. A restricted non-customer reviewer key delivered only through the private Partner Center field.

--- a/CUSTOMER_QUICKSTART.md
+++ b/CUSTOMER_QUICKSTART.md
@@ -51,4 +51,4 @@ Access to each dataset depends on the API key's current entitlements.
 - `#TIMEOUT`, `#NETWORK_OR_CORS`, or `#SERVER_ERROR`: check [OilPriceAPI status](https://status.oilpriceapi.com), retry once, then copy diagnostics from the pane.
 - `#NO_DATA` or `#INVALID_RESPONSE`: copy diagnostics and contact [support@oilpriceapi.com](mailto:support@oilpriceapi.com). Never send the API key.
 
-Current product scope and mutable facts are published in the [reviewed product-facts contract](https://api.oilpriceapi.com/product-facts.json).
+Current product scope and mutable facts are published in the [product-facts contract](https://api.oilpriceapi.com/product-facts.json).

--- a/CUSTOMER_QUICKSTART.md
+++ b/CUSTOMER_QUICKSTART.md
@@ -44,7 +44,10 @@ Access to each dataset depends on the API key's current entitlements.
 
 - `#AUTH_REQUIRED` or `#AUTH_INVALID`: open the OilPrice pane and save a current key.
 - `#UPGRADE_REQUIRED`: review the account's dataset and endpoint entitlement.
-- `#RATE_LIMITED`: wait before recalculating.
+- `#API_ACCESS_SUSPENDED`: contact [OilPriceAPI support](https://www.oilpriceapi.com/support); do not rotate the key or assume an upgrade will restore access.
+- `#EMAIL_CONFIRMATION_REQUIRED`: use the trusted OilPriceAPI confirmation recovery link shown in the formula error.
+- `#ACCESS_DENIED`: run **Test Key**, then contact support if the reason remains unknown.
+- `#RATE_LIMITED`: follow the retry time in the formula error, then retry.
 - `#TIMEOUT`, `#NETWORK_OR_CORS`, or `#SERVER_ERROR`: check [OilPriceAPI status](https://status.oilpriceapi.com), retry once, then copy diagnostics from the pane.
 - `#NO_DATA` or `#INVALID_RESPONSE`: copy diagnostics and contact [support@oilpriceapi.com](mailto:support@oilpriceapi.com). Never send the API key.
 

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -12,6 +12,20 @@ Do not send this document to customers. Do not claim AppSource, Marketplace, cus
 - Customer distribution tracker: `excel-energy-addin#16`.
 - Public self-serve install is not available until Microsoft distribution is complete.
 
+## Release Identity
+
+- The semantic add-in version is the package version and the value sent in
+  `X-Excel-Addin-Version` (candidate `1.1.1`).
+- Source `manifest.xml` is a template whose four-part version follows that
+  semantic release (`1.1.1.0` for this candidate).
+- `npm run build` stamps `dist/manifest.xml` with a distinct built manifest
+  version and cache token. A local build of this candidate produces `1.1.2.0`;
+  the Pages workflow uses `1.1.<GITHUB_RUN_NUMBER>.0`. This Office update
+  version does not change the semantic attribution header.
+- AppSource or centralized deployment must use one exact built manifest. Record
+  its source commit, workflow run, actual `<Version>`, hosted URL, and SHA-256
+  checksum. Never report the source template version as the submitted artifact.
+
 ## Release Gates
 
 All gates must be green before support or marketing sends customer install instructions.

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -22,7 +22,7 @@ All gates must be green before support or marketing sends customer install instr
    - `OILPRICE.PRICE` returns production data;
    - cell-reference recalc works after symbol change;
    - `OILPRICE.GET` returns a readable table;
-   - production logs show the expected non-customer test-account request and the browser request shape is limited to `authorization,content-type`;
+   - production logs show the expected non-customer test-account request and the browser request shape is `authorization,content-type,x-api-client,x-excel-addin-version`;
    - no raw API key appears in logs, screenshots, GitHub, or support text.
 2. Hosted assets pass:
    - `manifest.xml`, `functions.json`, `functions.js`, and `taskpane.html` return HTTP 200;

--- a/EXCEL_SUPPORT_RUNBOOK.md
+++ b/EXCEL_SUPPORT_RUNBOOK.md
@@ -84,18 +84,19 @@ the OilPrice frame.
 5. For a CORS failure, inspect the `OPTIONS` request and compare
    `Access-Control-Request-Headers` with `Access-Control-Allow-Headers`.
 
-The July 17, 2026 reproduction failed because the add-in requested
-`x-api-client`, but Cloudflare's preflight response did not allow it. The browser
-therefore blocked the GET before it reached the API. This is not a bad-key or
-Excel-connectivity failure. Version 1.0.2 and later restore browser compatibility by
-keeping cross-origin request headers to the edge-approved authorization and
-content-type set. The add-in version remains available in copied diagnostics.
+The July 17, 2026 reproduction failed because the edge preflight did not allow
+the add-in's attribution headers. The production edge rule now accepts the
+add-in's exact browser request shape:
+`authorization,content-type,x-api-client,x-excel-addin-version`. A preflight
+failure is not a bad-key or Excel-connectivity failure; inspect the public edge
+response before rotating a customer's key.
 
 ## Required Production Proof
 
-- The public preflight allows `authorization` and `content-type`.
-- Version 1.0.2 and later do not request `x-api-client`, `x-client-version`, or
-  `x-excel-addin-version` from Excel Online.
+- The public preflight allows
+  `authorization,content-type,x-api-client,x-excel-addin-version`.
+- The request contains `X-API-Client` and `X-Excel-Addin-Version` attribution;
+  the values contain no customer data or API-key material.
 - **Test Key** reports **Connected** and records an HTTP 200 diagnostic.
 - `OILPRICE.PRICE` returns a number and records a custom-function diagnostic.
 - Production logs contain the request at the matching diagnostic timestamp and

--- a/EXCEL_SUPPORT_RUNBOOK.md
+++ b/EXCEL_SUPPORT_RUNBOOK.md
@@ -64,7 +64,11 @@ through **Admin Center → Settings → Integrated apps → Upload custom apps**
 | Pane reports storage unavailable | Shared runtime/storage | Reload and confirm SharedRuntime 1.1 support |
 | `NETWORK_OR_CORS` while browser is online | Browser, CORS, CSP, proxy, or extension policy | Inspect the preflight and public CORS headers; do not rotate the key |
 | HTTP 401 / `AUTH_INVALID` | Authentication | Verify or replace the key |
-| HTTP 402/403/429 | Entitlement/quota/rate limit | Check the account and recovery path |
+| HTTP 402 / `UPGRADE_REQUIRED` | Quota or entitlement | Use the trusted upgrade URL returned by the API |
+| HTTP 403 / `API_ACCESS_SUSPENDED` | Account suspension | Contact support; do not send the customer to pricing |
+| HTTP 403 / `EMAIL_CONFIRMATION_REQUIRED` | Email confirmation gate | Use the trusted resend-confirmation recovery URL |
+| HTTP 403 / `ACCESS_DENIED` | Unknown or malformed denial | Run **Test Key**, copy diagnostics, and contact support |
+| HTTP 429 / `RATE_LIMITED` | Rate limit | Follow `Retry-After` or `X-RateLimit-Reset`, then retry |
 | `#NAME?` | Custom functions not registered | Inspect `functions.json`, `functions.js`, manifest namespace, and cache |
 | `#VALUE!` after registration | Shared runtime/function exception | Refresh diagnostics and inspect the custom-function request |
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -145,7 +145,10 @@ Until then, customer replies should say that we are validating the Excel add-in 
 | `#AUTH_REQUIRED` | No key is saved for formulas. | Open the OilPrice pane and save the key. |
 | `#AUTH_INVALID` | The key is invalid or expired. | Use a valid non-customer test key. |
 | `#UPGRADE_REQUIRED` | The key plan or quota does not cover the request. | Use an eligible test key or note the quota state. |
-| `#RATE_LIMITED` | The key hit a rate limit. | Wait or use a test key with available quota. |
+| `#API_ACCESS_SUSPENDED` | The account is suspended. | Contact support; do not rotate the key or infer that an upgrade will restore access. |
+| `#EMAIL_CONFIRMATION_REQUIRED` | The account must confirm its email. | Use the trusted OilPriceAPI recovery URL shown in the error. |
+| `#ACCESS_DENIED` | The API returned an unknown or unreadable 403 reason. | Run **Test Key**, copy diagnostics, and contact support if it continues. |
+| `#RATE_LIMITED` | The key hit a rate limit. | Follow `Retry-After` or `X-RateLimit-Reset` when shown, then retry. |
 | `#NO_DATA` | The API returned no matching data. | Check the code/query. |
 | `#NETWORK_ERROR` | Excel could not reach the API. | Check network and add-in connectivity. |
 | `#SERVER_ERROR` | API returned a server error. | Check production logs before retrying. |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -122,7 +122,8 @@ Confirm the production API saw the add-in request:
 
 - expected endpoint: `/v1/prices/latest`;
 - expected code: `BRENT_CRUDE_USD`;
-- expected browser request headers: `authorization,content-type`;
+- expected browser request headers:
+  `authorization,content-type,x-api-client,x-excel-addin-version`;
 - expected user/key: the non-customer test account;
 - no raw API key exposure.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This repository contains the preview OilPrice Excel add-in for refreshable OilPriceAPI formulas. It is not yet listed in Microsoft AppSource.
 
-Product facts are governed by the [versioned OilPriceAPI contract](https://api.oilpriceapi.com/product-facts.json), reviewed 2026-07-18. Latest available values include source timestamps; cadence varies by source, market hours, dataset, and account entitlement.
+Product facts are governed by the [versioned OilPriceAPI contract](https://api.oilpriceapi.com/product-facts.json). Latest available values include source timestamps; cadence varies by source, market hours, dataset, and account entitlement.
 
 ## Formula Contract
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -9,7 +9,7 @@
   <Id>f402ea85-7778-41f3-8cee-c3465c49ca8d</Id>
 
   <!-- Version -->
-  <Version>1.1.0.0</Version>
+  <Version>1.1.1.0</Version>
 
   <!-- Provider Name -->
   <ProviderName>OilPriceAPI</ProviderName>

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,30 +47,6 @@
         "url": "https://github.com/sponsors/philsturgeon"
       }
     },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@apidevtools/openapi-schemas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
@@ -3453,9 +3429,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4475,30 +4451,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/@microsoft/m365-spec-parser/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@microsoft/m365agentstoolkit-cli": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@microsoft/m365agentstoolkit-cli/-/m365agentstoolkit-cli-1.1.11.tgz",
@@ -4765,30 +4717,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@microsoft/teamsfx-core/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/jsonfile": {
@@ -7246,9 +7174,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9062,9 +8990,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -9653,9 +9581,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10153,9 +10081,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -11197,6 +11125,30 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "excel-energy-addin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "excel-energy-addin",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "excel-energy-addin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Excel add-in for refreshable OilPriceAPI formulas",
   "main": "dist/index.js",
   "scripts": {

--- a/public/taskpane.html
+++ b/public/taskpane.html
@@ -79,7 +79,7 @@
         <dl class="diagnostics-list">
           <div>
             <dt>Version</dt>
-            <dd id="diag-version">1.1.0</dd>
+            <dd id="diag-version">1.1.1</dd>
           </div>
           <div>
             <dt>Excel</dt>

--- a/public/taskpane.html
+++ b/public/taskpane.html
@@ -134,8 +134,8 @@
               <strong>#AUTH_INVALID</strong>: check or replace your API key.
             </p>
             <p>
-              <strong>#RATE_LIMITED</strong>: wait for quota reset, then
-              recalculate.
+              <strong>#RATE_LIMITED</strong>: follow the retry time shown, then
+              retry.
             </p>
             <p>
               <strong>#TIMEOUT</strong>: retry once, then check service status.
@@ -143,6 +143,18 @@
             <p>
               <strong>#UPGRADE_REQUIRED</strong>: your plan does not include
               that endpoint.
+            </p>
+            <p>
+              <strong>#API_ACCESS_SUSPENDED</strong>: contact support; replacing
+              the key or upgrading may not restore a suspended account.
+            </p>
+            <p>
+              <strong>#EMAIL_CONFIRMATION_REQUIRED</strong>: use the confirmation
+              recovery link shown in the formula error.
+            </p>
+            <p>
+              <strong>#ACCESS_DENIED</strong>: run Test Key, then contact support
+              if the reason remains unknown.
             </p>
             <p><strong>#NO_DATA</strong>: the API returned no matching data.</p>
             <p>

--- a/public/taskpane.html
+++ b/public/taskpane.html
@@ -141,8 +141,8 @@
               <strong>#TIMEOUT</strong>: retry once, then check service status.
             </p>
             <p>
-              <strong>#UPGRADE_REQUIRED</strong>: your plan does not include
-              that endpoint.
+              <strong>#UPGRADE_REQUIRED</strong>: quota or account entitlement
+              does not cover that request; use the trusted pricing link shown.
             </p>
             <p>
               <strong>#API_ACCESS_SUSPENDED</strong>: contact support; replacing
@@ -197,10 +197,10 @@
 
       <p class="diagnostics-note">
         <a
-          href="https://api.oilpriceapi.com/product-facts.json"
-          target="_blank"
-          rel="noopener"
-          >Product facts reviewed July 18, 2026</a
+              href="https://api.oilpriceapi.com/product-facts.json"
+              target="_blank"
+              rel="noopener"
+              >Current product facts contract</a
         >. Data cadence and access vary by source, market hours, dataset, and
         account entitlement.
       </p>

--- a/src/functions/functions.ts
+++ b/src/functions/functions.ts
@@ -10,16 +10,16 @@
 /// <reference types="@types/office-js" />
 
 import {
+  OILPRICEAPI_EXCEL_CLIENT,
+  OILPRICEAPI_EXCEL_VERSION,
+} from "../utils/client-attribution";
+import {
   RUNTIME_DIAGNOSTIC_STORAGE_KEY,
   classifyNetworkFailure,
   createRuntimeDiagnostic,
   requestIdFromResponse,
   RuntimeDiagnostic,
 } from "../utils/runtime-diagnostics";
-
-// #6167 — sent as X-Excel-Addin-Version so the server can attribute
-// this add-in (MinimalAnalyticsService maps it to client_type sdk-excel).
-const ADDIN_VERSION = "1.1.0";
 
 declare const OfficeRuntime: {
   storage: {
@@ -296,29 +296,41 @@ async function persistRuntimeDiagnostic(
 
 function parseResponseError(response: Response): ResponseError {
   if (response.status === 401) {
-    return { code: "AUTH_INVALID", message: "API key invalid or expired" };
+    return {
+      code: "AUTH_INVALID",
+      message:
+        "API key invalid or expired. Open the OilPrice pane and replace it",
+    };
   }
 
   if (response.status === 403) {
     return {
       code: "UPGRADE_REQUIRED",
-      message: "Plan does not include this endpoint",
+      message:
+        "Plan does not include this endpoint. Review https://www.oilpriceapi.com/pricing",
     };
   }
 
   if (response.status === 402) {
     return {
       code: "UPGRADE_REQUIRED",
-      message: "Quota or plan limit reached",
+      message:
+        "Quota or plan limit reached. Review https://www.oilpriceapi.com/pricing",
     };
   }
 
   if (response.status === 404) {
-    return { code: "NO_DATA", message: "No data returned" };
+    return {
+      code: "NO_DATA",
+      message: "No data returned. Check the commodity code or query",
+    };
   }
 
   if (response.status === 429) {
-    return { code: "RATE_LIMITED", message: "Limit reached. Try later" };
+    return {
+      code: "RATE_LIMITED",
+      message: "Limit reached. Wait, then recalculate",
+    };
   }
 
   if (response.status >= 500) {
@@ -404,7 +416,8 @@ async function apiGet(
   const throwTimeout = async (): Promise<never> => {
     const responseError: ResponseError = {
       code: "TIMEOUT",
-      message: "OilPriceAPI did not respond in time",
+      message:
+        "OilPriceAPI did not respond in time. Retry, then use Test Key after checking service status",
     };
     await persistRuntimeDiagnostic(
       createRuntimeDiagnostic({
@@ -427,8 +440,8 @@ async function apiGet(
           "Content-Type": "application/json",
           // See taskpane.ts — Office.js locks User-Agent; X-API-Client is how
           // the server classifies this add-in. (#6167)
-          "X-API-Client": "oilpriceapi-excel",
-          "X-Excel-Addin-Version": ADDIN_VERSION,
+          "X-API-Client": OILPRICEAPI_EXCEL_CLIENT,
+          "X-Excel-Addin-Version": OILPRICEAPI_EXCEL_VERSION,
         },
         signal: controller.signal,
       });
@@ -448,7 +461,7 @@ async function apiGet(
       );
       throw {
         code: failure.code,
-        message: failure.message,
+        message: `${failure.message}. ${failure.recovery}`,
       } satisfies ResponseError;
     }
 
@@ -1017,7 +1030,10 @@ export async function oilpricePrice(code: string): Promise<number | string> {
     );
     const data = payload?.data;
     if (data === null || data === undefined) {
-      return cellError("NO_DATA", "No data returned");
+      return cellError(
+        "NO_DATA",
+        "No data returned. Check the commodity code or query",
+      );
     }
     if (typeof data !== "object") {
       return cellError("INVALID_RESPONSE", "API returned a malformed price");
@@ -1119,7 +1135,10 @@ async function fetchLatestQuote(code: string): Promise<Record<string, any>> {
   );
   const data = payload?.data;
   if (!data || typeof data !== "object") {
-    throw { code: "NO_DATA", message: "No data returned" } as ResponseError;
+    throw {
+      code: "NO_DATA",
+      message: "No data returned. Check the commodity code or query",
+    } as ResponseError;
   }
   // Belt-and-suspenders: if the API ever returns HTTP 200 with an error body
   // (e.g. { data: { error: "invalid_code", message: "Did you mean ..." } }),

--- a/src/functions/functions.ts
+++ b/src/functions/functions.ts
@@ -20,6 +20,7 @@ import {
   requestIdFromResponse,
   RuntimeDiagnostic,
 } from "../utils/runtime-diagnostics";
+import { classifyApiErrorResponse } from "../utils/http-error";
 
 declare const OfficeRuntime: {
   storage: {
@@ -294,52 +295,6 @@ async function persistRuntimeDiagnostic(
   }
 }
 
-function parseResponseError(response: Response): ResponseError {
-  if (response.status === 401) {
-    return {
-      code: "AUTH_INVALID",
-      message:
-        "API key invalid or expired. Open the OilPrice pane and replace it",
-    };
-  }
-
-  if (response.status === 403) {
-    return {
-      code: "UPGRADE_REQUIRED",
-      message:
-        "Plan does not include this endpoint. Review https://www.oilpriceapi.com/pricing",
-    };
-  }
-
-  if (response.status === 402) {
-    return {
-      code: "UPGRADE_REQUIRED",
-      message:
-        "Quota or plan limit reached. Review https://www.oilpriceapi.com/pricing",
-    };
-  }
-
-  if (response.status === 404) {
-    return {
-      code: "NO_DATA",
-      message: "No data returned. Check the commodity code or query",
-    };
-  }
-
-  if (response.status === 429) {
-    return {
-      code: "RATE_LIMITED",
-      message: "Limit reached. Wait, then recalculate",
-    };
-  }
-
-  if (response.status >= 500) {
-    return { code: "SERVER_ERROR", message: "API temporarily unavailable" };
-  }
-
-  return { code: "ERROR", message: `HTTP ${response.status}` };
-}
-
 function normalizePath(path: string): string {
   const trimmed = (path || "").trim();
   if (!trimmed.startsWith("/v1/")) {
@@ -468,33 +423,14 @@ async function apiGet(
     const requestId = requestIdFromResponse(response);
 
     if (!response.ok) {
-      let responseError = parseResponseError(response);
-      // Validation errors (e.g. an invalid commodity code) arrive with a helpful
-      // "did you mean" message in the JSON body. Surface that message rather than
-      // a bare "HTTP 400" so the worksheet shows the suggestion.
-      try {
-        const errorBody = await response.json();
-        const errorData = errorBody?.data ?? errorBody;
-        if (
-          (response.status === 400 || response.status === 422) &&
-          errorData &&
-          typeof errorData === "object" &&
-          typeof errorData.error === "string"
-        ) {
-          responseError = {
-            code: "INVALID_CODE",
-            message:
-              typeof errorData.message === "string" && errorData.message.trim()
-                ? errorData.message
-                : responseError.message,
-          };
-        }
-      } catch {
-        if (controller.signal.aborted) {
-          await throwTimeout();
-        }
-        // Non-JSON error body: keep the status-derived error.
+      const classified = await classifyApiErrorResponse(response);
+      if (controller.signal.aborted) {
+        await throwTimeout();
       }
+      const responseError: ResponseError = {
+        code: classified.code,
+        message: classified.message,
+      };
       await persistRuntimeDiagnostic(
         createRuntimeDiagnostic({
           source: "custom-function",

--- a/src/taskpane/taskpane.ts
+++ b/src/taskpane/taskpane.ts
@@ -11,6 +11,7 @@ import {
   parseRuntimeDiagnostic,
   requestIdFromResponse,
 } from "../utils/runtime-diagnostics";
+import { classifyApiErrorResponse } from "../utils/http-error";
 
 declare const OfficeRuntime: {
   storage: {
@@ -253,64 +254,6 @@ function requirementSupportLabel(): string {
   }
 }
 
-interface HttpResult {
-  label: string;
-  code: string;
-  message: string;
-}
-
-function classifyHttpResult(status: number): HttpResult {
-  if (status === 401) {
-    return {
-      label: "Invalid key",
-      code: "AUTH_INVALID",
-      message: "API key invalid or expired. Replace it in the OilPrice pane.",
-    };
-  }
-  if (status === 402) {
-    return {
-      label: "Quota reached",
-      code: "UPGRADE_REQUIRED",
-      message:
-        "Quota or plan limit reached. Review https://www.oilpriceapi.com/pricing.",
-    };
-  }
-  if (status === 403) {
-    return {
-      label: "Upgrade required",
-      code: "UPGRADE_REQUIRED",
-      message:
-        "Your plan does not include this endpoint. Review https://www.oilpriceapi.com/pricing.",
-    };
-  }
-  if (status === 429) {
-    return {
-      label: "Rate limited",
-      code: "RATE_LIMITED",
-      message: "Rate limit reached. Wait, then try Test Key again.",
-    };
-  }
-  if (status === 404) {
-    return {
-      label: "No data",
-      code: "NO_DATA",
-      message: "No data returned. Check the commodity code or query.",
-    };
-  }
-  if (status >= 500) {
-    return {
-      label: "Server error",
-      code: "SERVER_ERROR",
-      message: "OilPriceAPI is temporarily unavailable.",
-    };
-  }
-  return {
-    label: `HTTP ${status}`,
-    code: "HTTP_ERROR",
-    message: `OilPriceAPI returned HTTP ${status}.`,
-  };
-}
-
 async function testConnection(): Promise<void> {
   let apiKey: string | null;
   try {
@@ -355,7 +298,10 @@ async function testConnection(): Promise<void> {
     const requestId = requestIdFromResponse(response);
 
     if (!response.ok) {
-      const result = classifyHttpResult(response.status);
+      const result = await classifyApiErrorResponse(response);
+      if (controller.signal.aborted) {
+        throw new Error("Request timed out while reading the error response");
+      }
       await recordRuntimeDiagnostic(
         createRuntimeDiagnostic({
           source: "taskpane",

--- a/src/taskpane/taskpane.ts
+++ b/src/taskpane/taskpane.ts
@@ -12,10 +12,6 @@ import {
   requestIdFromResponse,
 } from "../utils/runtime-diagnostics";
 
-// #6167 — sent as X-Excel-Addin-Version so the server can attribute
-// this add-in (MinimalAnalyticsService maps it to client_type sdk-excel).
-const ADDIN_VERSION = "1.1.0";
-
 declare const OfficeRuntime: {
   storage: {
     getItem(key: string): Promise<string | null>;
@@ -268,28 +264,37 @@ function classifyHttpResult(status: number): HttpResult {
     return {
       label: "Invalid key",
       code: "AUTH_INVALID",
-      message: "API key invalid or expired.",
+      message: "API key invalid or expired. Replace it in the OilPrice pane.",
     };
   }
   if (status === 402) {
     return {
       label: "Quota reached",
       code: "UPGRADE_REQUIRED",
-      message: "Quota or plan limit reached.",
+      message:
+        "Quota or plan limit reached. Review https://www.oilpriceapi.com/pricing.",
     };
   }
   if (status === 403) {
     return {
       label: "Upgrade required",
       code: "UPGRADE_REQUIRED",
-      message: "Your plan does not include this endpoint.",
+      message:
+        "Your plan does not include this endpoint. Review https://www.oilpriceapi.com/pricing.",
     };
   }
   if (status === 429) {
     return {
       label: "Rate limited",
       code: "RATE_LIMITED",
-      message: "Rate limit reached. Try later.",
+      message: "Rate limit reached. Wait, then try Test Key again.",
+    };
+  }
+  if (status === 404) {
+    return {
+      label: "No data",
+      code: "NO_DATA",
+      message: "No data returned. Check the commodity code or query.",
     };
   }
   if (status >= 500) {
@@ -340,8 +345,8 @@ async function testConnection(): Promise<void> {
         // maps oilpriceapi-excel -> client_type 'sdk-excel'). Without it every
         // call from this add-in records as client_type 'unknown' and the add-in
         // is invisible in adoption reporting. (#6167)
-        "X-API-Client": "oilpriceapi-excel",
-        "X-Excel-Addin-Version": ADDIN_VERSION,
+        "X-API-Client": OILPRICEAPI_EXCEL_CLIENT,
+        "X-Excel-Addin-Version": OILPRICEAPI_EXCEL_VERSION,
       },
       signal: controller.signal,
     });

--- a/src/utils/client-attribution.ts
+++ b/src/utils/client-attribution.ts
@@ -1,2 +1,2 @@
-export const OILPRICEAPI_EXCEL_VERSION = "1.1.0";
+export const OILPRICEAPI_EXCEL_VERSION = "1.1.1";
 export const OILPRICEAPI_EXCEL_CLIENT = `oilpriceapi-excel/${OILPRICEAPI_EXCEL_VERSION}`;

--- a/src/utils/http-error.ts
+++ b/src/utils/http-error.ts
@@ -1,0 +1,281 @@
+export interface ClassifiedApiError {
+  label: string;
+  code: string;
+  message: string;
+  apiMessage?: string;
+}
+
+const MAX_ERROR_BODY_CHARS = 16_384;
+const MAX_ERROR_MESSAGE_CHARS = 320;
+const MAX_RECOVERY_URL_CHARS = 512;
+const SUPPORT_URL = "https://www.oilpriceapi.com/support";
+const PRICING_URL = "https://www.oilpriceapi.com/pricing";
+const CONFIRMATION_URL =
+  "https://www.oilpriceapi.com/auth/resend-confirmation";
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function boundedString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const valueWithoutControls = value.replace(/[\u0000-\u001f\u007f]/g, " ").trim();
+  if (!valueWithoutControls) return undefined;
+  return valueWithoutControls.slice(0, maxLength);
+}
+
+function canonicalErrorObject(payload: unknown): JsonObject | null {
+  if (!isObject(payload)) return null;
+  if (isObject(payload.error)) return payload.error;
+  if (isObject(payload.data)) {
+    return isObject(payload.data.error) ? payload.data.error : payload.data;
+  }
+  return payload;
+}
+
+function fieldFrom(
+  primary: JsonObject | null,
+  root: unknown,
+  field: string,
+): unknown {
+  if (primary && primary[field] !== undefined) return primary[field];
+  return isObject(root) ? root[field] : undefined;
+}
+
+function trustedOilPriceUrl(value: unknown, fallback: string): string {
+  const candidate = boundedString(value, MAX_RECOVERY_URL_CHARS);
+  if (!candidate) return fallback;
+  try {
+    const parsed = new URL(candidate);
+    const trustedHost =
+      parsed.hostname === "oilpriceapi.com" ||
+      parsed.hostname.endsWith(".oilpriceapi.com");
+    if (
+      parsed.protocol !== "https:" ||
+      !trustedHost ||
+      parsed.username ||
+      parsed.password ||
+      (parsed.port && parsed.port !== "443")
+    ) {
+      return fallback;
+    }
+    return candidate;
+  } catch {
+    return fallback;
+  }
+}
+
+async function readBoundedErrorPayload(response: Response): Promise<unknown> {
+  try {
+    const contentLength = Number(response.headers?.get("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > MAX_ERROR_BODY_CHARS) {
+      return null;
+    }
+
+    if (response.body && typeof response.body.getReader === "function") {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let byteLength = 0;
+      let text = "";
+      while (true) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        byteLength += chunk.value.byteLength;
+        if (byteLength > MAX_ERROR_BODY_CHARS) {
+          await reader.cancel();
+          return null;
+        }
+        text += decoder.decode(chunk.value, { stream: true });
+      }
+      text += decoder.decode();
+      if (!text || text.length > MAX_ERROR_BODY_CHARS) return null;
+      return JSON.parse(text);
+    }
+
+    if (typeof response.text === "function") {
+      const text = await response.text();
+      if (!text || text.length > MAX_ERROR_BODY_CHARS) return null;
+      return JSON.parse(text);
+    }
+
+    // Unit fixtures and older Office WebView shims may expose json() without
+    // text(). The serialized bound keeps the same fail-closed contract.
+    if (typeof response.json === "function") {
+      const payload = await response.json();
+      return JSON.stringify(payload).length <= MAX_ERROR_BODY_CHARS
+        ? payload
+        : null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function headerValue(response: Response, name: string): string | null {
+  try {
+    return response.headers?.get(name) || null;
+  } catch {
+    return null;
+  }
+}
+
+function retryDelaySeconds(response: Response): number | null {
+  const retryAfter = headerValue(response, "retry-after");
+  if (retryAfter) {
+    const numeric = Number(retryAfter);
+    if (Number.isFinite(numeric) && numeric >= 0) {
+      return Math.min(Math.max(Math.ceil(numeric), 1), 604_800);
+    }
+    const retryAt = Date.parse(retryAfter);
+    if (Number.isFinite(retryAt) && retryAt > Date.now()) {
+      return Math.min(Math.ceil((retryAt - Date.now()) / 1000), 604_800);
+    }
+  }
+
+  const resetAt = Number(headerValue(response, "x-ratelimit-reset"));
+  if (Number.isFinite(resetAt) && resetAt > Date.now() / 1000) {
+    return Math.min(Math.ceil(resetAt - Date.now() / 1000), 604_800);
+  }
+  return null;
+}
+
+function retryMessage(response: Response): string {
+  const seconds = retryDelaySeconds(response);
+  if (seconds === null) return "Wait briefly, then retry.";
+  if (seconds < 90) return `Retry after ${seconds} seconds.`;
+  if (seconds < 5_400) {
+    return `Retry after about ${Math.ceil(seconds / 60)} minutes.`;
+  }
+  return `Retry after about ${Math.ceil(seconds / 3_600)} hours.`;
+}
+
+export async function classifyApiErrorResponse(
+  response: Response,
+): Promise<ClassifiedApiError> {
+  const payload = await readBoundedErrorPayload(response);
+  const error = canonicalErrorObject(payload);
+  const apiCode = boundedString(
+    fieldFrom(error, payload, "code") ?? fieldFrom(error, payload, "error_code"),
+    64,
+  );
+  const normalizedCode =
+    apiCode && /^[A-Z0-9_]+$/.test(apiCode) ? apiCode : undefined;
+  const apiMessage = boundedString(
+    fieldFrom(error, payload, "message"),
+    MAX_ERROR_MESSAGE_CHARS,
+  );
+  const details = error && isObject(error.details) ? error.details : null;
+  const recoveryUrl =
+    fieldFrom(error, payload, "recovery_url") ?? details?.recovery_url;
+  const upgradeUrl =
+    fieldFrom(error, payload, "upgrade_url") ?? details?.upgrade_url;
+
+  if (response.status === 401) {
+    return {
+      label: "Invalid key",
+      code: "AUTH_INVALID",
+      message:
+        "API key invalid or expired. Open the OilPrice pane and replace it",
+      apiMessage,
+    };
+  }
+
+  if (response.status === 403) {
+    if (normalizedCode === "API_ACCESS_SUSPENDED") {
+      return {
+        label: "Access suspended",
+        code: "API_ACCESS_SUSPENDED",
+        message: `API access is suspended. Contact support: ${SUPPORT_URL}`,
+        apiMessage,
+      };
+    }
+    if (normalizedCode === "EMAIL_CONFIRMATION_REQUIRED") {
+      return {
+        label: "Confirm email",
+        code: "EMAIL_CONFIRMATION_REQUIRED",
+        message:
+          "Confirm your email to continue. Request a new confirmation: " +
+          trustedOilPriceUrl(recoveryUrl, CONFIRMATION_URL),
+        apiMessage,
+      };
+    }
+    if (normalizedCode === "FORBIDDEN") {
+      return {
+        label: "Upgrade required",
+        code: "UPGRADE_REQUIRED",
+        message:
+          "This account does not include the requested feature. Review " +
+          trustedOilPriceUrl(upgradeUrl, PRICING_URL),
+        apiMessage,
+      };
+    }
+    return {
+      label: "Access denied",
+      code: "ACCESS_DENIED",
+      message:
+        "Access was denied for a reason the add-in could not verify. " +
+        `Use Test Key, then contact support: ${SUPPORT_URL}`,
+      apiMessage,
+    };
+  }
+
+  if (response.status === 402) {
+    return {
+      label: "Quota reached",
+      code: "UPGRADE_REQUIRED",
+      message:
+        "Quota or plan limit reached. Review " +
+        trustedOilPriceUrl(upgradeUrl, PRICING_URL),
+      apiMessage,
+    };
+  }
+
+  if (response.status === 404) {
+    return {
+      label: "No data",
+      code: "NO_DATA",
+      message: "No data returned. Check the commodity code or query",
+      apiMessage,
+    };
+  }
+
+  if (response.status === 429) {
+    return {
+      label: "Rate limited",
+      code: "RATE_LIMITED",
+      message: `Rate limit reached. ${retryMessage(response)}`,
+      apiMessage,
+    };
+  }
+
+  if (
+    (response.status === 400 || response.status === 422) &&
+    apiMessage
+  ) {
+    return {
+      label: "Invalid request",
+      code: "INVALID_CODE",
+      message: apiMessage,
+      apiMessage,
+    };
+  }
+
+  if (response.status >= 500) {
+    return {
+      label: "Server error",
+      code: "SERVER_ERROR",
+      message: "OilPriceAPI is temporarily unavailable.",
+      apiMessage,
+    };
+  }
+
+  return {
+    label: `HTTP ${response.status}`,
+    code: "HTTP_ERROR",
+    message: `OilPriceAPI returned HTTP ${response.status}.`,
+    apiMessage,
+  };
+}

--- a/tests/unit/build-version.test.ts
+++ b/tests/unit/build-version.test.ts
@@ -46,14 +46,12 @@ describe("release version contract", () => {
       path.join(root, "src", "taskpane", "taskpane.ts"),
       "utf8",
     );
-    const operatorGuides = [
+    const operatorGuideFiles = [
       "ADDIN_ACTIVATION_CHECKLIST.md",
       "DISTRIBUTION.md",
       "EXCEL_SUPPORT_RUNBOOK.md",
       "INSTALL.md",
-    ]
-      .map((file) => fs.readFileSync(path.join(root, file), "utf8"))
-      .join("\n");
+    ];
 
     for (const source of [functions, taskpane]) {
       expect(source).toContain('"X-API-Client": OILPRICEAPI_EXCEL_CLIENT');
@@ -61,12 +59,15 @@ describe("release version contract", () => {
         '"X-Excel-Addin-Version": OILPRICEAPI_EXCEL_VERSION',
       );
     }
-    expect(operatorGuides).toMatch(
-      /authorization,content-type,x-api-client,x-excel-addin-version/i,
-    );
-    expect(operatorGuides).not.toMatch(/do not request `x-api-client`/i);
-    expect(operatorGuides).not.toMatch(
-      /request shape is limited to `authorization,content-type`/i,
-    );
+    for (const file of operatorGuideFiles) {
+      const guide = fs.readFileSync(path.join(root, file), "utf8");
+      expect(guide).toMatch(
+        /authorization,content-type,x-api-client,x-excel-addin-version/i,
+      );
+      expect(guide).not.toMatch(/do not request `x-api-client`/i);
+      expect(guide).not.toMatch(
+        /request shape is limited to `authorization,content-type`/i,
+      );
+    }
   });
 });

--- a/tests/unit/build-version.test.ts
+++ b/tests/unit/build-version.test.ts
@@ -70,4 +70,24 @@ describe("release version contract", () => {
       );
     }
   });
+
+  it("documents every customer-visible structured 403 recovery", () => {
+    const taskpane = fs.readFileSync(
+      path.join(root, "public", "taskpane.html"),
+      "utf8",
+    );
+    const quickstart = fs.readFileSync(
+      path.join(root, "CUSTOMER_QUICKSTART.md"),
+      "utf8",
+    );
+    for (const code of [
+      "API_ACCESS_SUSPENDED",
+      "EMAIL_CONFIRMATION_REQUIRED",
+      "ACCESS_DENIED",
+      "UPGRADE_REQUIRED",
+    ]) {
+      expect(taskpane).toContain(`#${code}`);
+      expect(quickstart).toContain(`#${code}`);
+    }
+  });
 });

--- a/tests/unit/build-version.test.ts
+++ b/tests/unit/build-version.test.ts
@@ -35,4 +35,37 @@ describe("release version contract", () => {
     expect(stampScript).toContain("parts[0]");
     expect(stampScript).toContain("parts[1]");
   });
+
+  it("keeps browser attribution source and operator guidance aligned", () => {
+    const functions = fs.readFileSync(
+      path.join(root, "src", "functions", "functions.ts"),
+      "utf8",
+    );
+    const taskpane = fs.readFileSync(
+      path.join(root, "src", "taskpane", "taskpane.ts"),
+      "utf8",
+    );
+    const operatorGuides = [
+      "ADDIN_ACTIVATION_CHECKLIST.md",
+      "DISTRIBUTION.md",
+      "EXCEL_SUPPORT_RUNBOOK.md",
+      "INSTALL.md",
+    ]
+      .map((file) => fs.readFileSync(path.join(root, file), "utf8"))
+      .join("\n");
+
+    for (const source of [functions, taskpane]) {
+      expect(source).toContain('"X-API-Client": OILPRICEAPI_EXCEL_CLIENT');
+      expect(source).toContain(
+        '"X-Excel-Addin-Version": OILPRICEAPI_EXCEL_VERSION',
+      );
+    }
+    expect(operatorGuides).toMatch(
+      /authorization,content-type,x-api-client,x-excel-addin-version/i,
+    );
+    expect(operatorGuides).not.toMatch(/do not request `x-api-client`/i);
+    expect(operatorGuides).not.toMatch(
+      /request shape is limited to `authorization,content-type`/i,
+    );
+  });
 });

--- a/tests/unit/build-version.test.ts
+++ b/tests/unit/build-version.test.ts
@@ -89,5 +89,42 @@ describe("release version contract", () => {
       expect(taskpane).toContain(`#${code}`);
       expect(quickstart).toContain(`#${code}`);
     }
+    expect(taskpane).toMatch(
+      /#UPGRADE_REQUIRED<\/strong>: (?:your )?quota or account entitlement/i,
+    );
+    const productFactSurfaces = [
+      taskpane,
+      quickstart,
+      fs.readFileSync(path.join(root, "README.md"), "utf8"),
+      fs.readFileSync(path.join(root, "APPSOURCE_METADATA.md"), "utf8"),
+    ].join("\n");
+    expect(productFactSurfaces).not.toMatch(
+      /(?:product facts|product-facts)[^\n]{0,120}(?:reviewed|2026-0[67]|schema `1\.0\.0`)/i,
+    );
+  });
+
+  it("keeps dependency audit in the hosted release gate", () => {
+    for (const file of ["test.yml", "github-pages.yml"]) {
+      const workflow = fs.readFileSync(
+        path.join(root, ".github", "workflows", file),
+        "utf8",
+      );
+      expect(workflow).toContain("npm audit --audit-level=moderate");
+    }
+  });
+
+  it("distinguishes the semantic release from the submitted manifest build", () => {
+    const distribution = fs.readFileSync(
+      path.join(root, "DISTRIBUTION.md"),
+      "utf8",
+    );
+    const metadata = fs.readFileSync(
+      path.join(root, "APPSOURCE_METADATA.md"),
+      "utf8",
+    );
+    expect(distribution).toMatch(/semantic add-in version/i);
+    expect(distribution).toMatch(/built manifest\s+version/i);
+    expect(metadata).toMatch(/exact submitted manifest/i);
+    expect(metadata).toMatch(/sha-256/i);
   });
 });

--- a/tests/unit/build-version.test.ts
+++ b/tests/unit/build-version.test.ts
@@ -18,6 +18,7 @@ describe("release version contract", () => {
       "utf8",
     );
 
+    expect(packageVersion).toBe("1.1.1");
     expect(manifest).toContain(`<Version>${packageVersion}.0</Version>`);
     expect(taskpane).toContain(`id="diag-version">${packageVersion}</dd>`);
     expect(attribution).toContain(

--- a/tests/unit/functions-realshape.test.ts
+++ b/tests/unit/functions-realshape.test.ts
@@ -397,7 +397,7 @@ describe("Helper edge cases and error handling", () => {
       status: 401,
     });
     await expect(oilpricePriceStatus("BRENT_CRUDE_USD")).resolves.toBe(
-      "#AUTH_INVALID: API key invalid or expired",
+      "#AUTH_INVALID: API key invalid or expired. Open the OilPrice pane and replace it",
     );
   });
 
@@ -424,7 +424,7 @@ describe("Helper edge cases and error handling", () => {
       new TypeError("Failed to fetch"),
     );
     await expect(oilpricePriceUnit("BRENT_CRUDE_USD")).resolves.toBe(
-      "#NETWORK_OR_CORS: The browser or CORS policy blocked the API request",
+      "#NETWORK_OR_CORS: The browser or CORS policy blocked the API request. Copy diagnostics and contact support. Do not replace the API key unless the pane reports AUTH_INVALID.",
     );
   });
 

--- a/tests/unit/functions.test.ts
+++ b/tests/unit/functions.test.ts
@@ -44,8 +44,8 @@ describe("OilPrice custom functions MVP", () => {
           headers: {
             Authorization: "Token test-api-key-123",
             "Content-Type": "application/json",
-            "X-API-Client": "oilpriceapi-excel/1.1.0",
-            "X-Excel-Addin-Version": "1.1.0",
+            "X-API-Client": "oilpriceapi-excel/1.1.1",
+            "X-Excel-Addin-Version": "1.1.1",
           },
           signal: expect.any(Object),
         }),

--- a/tests/unit/functions.test.ts
+++ b/tests/unit/functions.test.ts
@@ -44,6 +44,8 @@ describe("OilPrice custom functions MVP", () => {
           headers: {
             Authorization: "Token test-api-key-123",
             "Content-Type": "application/json",
+            "X-API-Client": "oilpriceapi-excel/1.1.0",
+            "X-Excel-Addin-Version": "1.1.0",
           },
           signal: expect.any(Object),
         }),
@@ -77,7 +79,7 @@ describe("OilPrice custom functions MVP", () => {
       });
 
       await expect(oilpricePrice("BRENT_CRUDE_USD")).resolves.toBe(
-        "#AUTH_INVALID: API key invalid or expired",
+        "#AUTH_INVALID: API key invalid or expired. Open the OilPrice pane and replace it",
       );
     });
 
@@ -88,7 +90,7 @@ describe("OilPrice custom functions MVP", () => {
       });
 
       await expect(oilpricePrice("BRENT_CRUDE_USD")).resolves.toBe(
-        "#RATE_LIMITED: Limit reached. Try later",
+        "#RATE_LIMITED: Limit reached. Wait, then recalculate",
       );
     });
 
@@ -99,7 +101,7 @@ describe("OilPrice custom functions MVP", () => {
       });
 
       await expect(oilpricePrice("BRENT_CRUDE_USD")).resolves.toBe(
-        "#UPGRADE_REQUIRED: Quota or plan limit reached",
+        "#UPGRADE_REQUIRED: Quota or plan limit reached. Review https://www.oilpriceapi.com/pricing",
       );
     });
 
@@ -111,7 +113,20 @@ describe("OilPrice custom functions MVP", () => {
       });
 
       await expect(oilpricePrice("LOCKED_COMMODITY")).resolves.toBe(
-        "#UPGRADE_REQUIRED: Plan does not include this endpoint",
+        "#UPGRADE_REQUIRED: Plan does not include this endpoint. Review https://www.oilpriceapi.com/pricing",
+      );
+    });
+
+    it("maps a missing API record to a recoverable NO_DATA error", async () => {
+      ((globalThis as any).fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+        json: async () => ({}),
+      });
+
+      await expect(oilpricePrice("MISSING_CODE")).resolves.toBe(
+        "#NO_DATA: No data returned. Check the commodity code or query",
       );
     });
 
@@ -124,7 +139,7 @@ describe("OilPrice custom functions MVP", () => {
       });
 
       await expect(oilpricePrice("BRENT_CRUDE_USD")).resolves.toBe(
-        "#NO_DATA: No data returned",
+        "#NO_DATA: No data returned. Check the commodity code or query",
       );
     });
 
@@ -178,7 +193,7 @@ describe("OilPrice custom functions MVP", () => {
       await jest.advanceTimersByTimeAsync(15_000);
 
       await expect(resultPromise).resolves.toBe(
-        "#TIMEOUT: OilPriceAPI did not respond in time",
+        "#TIMEOUT: OilPriceAPI did not respond in time. Retry, then use Test Key after checking service status",
       );
       const [, rawDiagnostic] =
         mockStorage.setItem.mock.calls[
@@ -212,7 +227,7 @@ describe("OilPrice custom functions MVP", () => {
       await jest.advanceTimersByTimeAsync(15_000);
 
       await expect(resultPromise).resolves.toBe(
-        "#TIMEOUT: OilPriceAPI did not respond in time",
+        "#TIMEOUT: OilPriceAPI did not respond in time. Retry, then use Test Key after checking service status",
       );
       jest.useRealTimers();
     });
@@ -240,7 +255,7 @@ describe("OilPrice custom functions MVP", () => {
       await jest.advanceTimersByTimeAsync(15_000);
 
       await expect(resultPromise).resolves.toBe(
-        "#TIMEOUT: OilPriceAPI did not respond in time",
+        "#TIMEOUT: OilPriceAPI did not respond in time. Retry, then use Test Key after checking service status",
       );
       jest.useRealTimers();
     });
@@ -251,7 +266,7 @@ describe("OilPrice custom functions MVP", () => {
       );
 
       await expect(oilpricePrice("BRENT_CRUDE_USD")).resolves.toBe(
-        "#NETWORK_OR_CORS: The browser or CORS policy blocked the API request",
+        "#NETWORK_OR_CORS: The browser or CORS policy blocked the API request. Copy diagnostics and contact support. Do not replace the API key unless the pane reports AUTH_INVALID.",
       );
 
       const [, rawDiagnostic] =

--- a/tests/unit/functions.test.ts
+++ b/tests/unit/functions.test.ts
@@ -90,7 +90,7 @@ describe("OilPrice custom functions MVP", () => {
       });
 
       await expect(oilpricePrice("BRENT_CRUDE_USD")).resolves.toBe(
-        "#RATE_LIMITED: Limit reached. Wait, then recalculate",
+        "#RATE_LIMITED: Rate limit reached. Wait briefly, then retry.",
       );
     });
 
@@ -109,11 +109,74 @@ describe("OilPrice custom functions MVP", () => {
       ((globalThis as any).fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
         status: 403,
-        json: async () => ({ error: "commodity_locked" }),
+        headers: new Headers(),
+        json: async () => ({
+          error: {
+            code: "FORBIDDEN",
+            upgrade_url:
+              "https://www.oilpriceapi.com/pricing?feature=locked-commodity",
+          },
+        }),
       });
 
       await expect(oilpricePrice("LOCKED_COMMODITY")).resolves.toBe(
-        "#UPGRADE_REQUIRED: Plan does not include this endpoint. Review https://www.oilpriceapi.com/pricing",
+        "#UPGRADE_REQUIRED: This account does not include the requested feature. Review https://www.oilpriceapi.com/pricing?feature=locked-commodity",
+      );
+    });
+
+    it("maps a suspended account to support instead of an upgrade", async () => {
+      ((globalThis as any).fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        headers: new Headers(),
+        json: async () => ({
+          error: {
+            code: "API_ACCESS_SUSPENDED",
+            message: "Your API access has been suspended.",
+            upgrade_url: "https://www.oilpriceapi.com/pricing?suspended=1",
+          },
+        }),
+      });
+
+      await expect(oilpricePrice("BRENT_CRUDE_USD")).resolves.toBe(
+        "#API_ACCESS_SUSPENDED: API access is suspended. Contact support: https://www.oilpriceapi.com/support",
+      );
+    });
+
+    it("maps an unconfirmed account to the canonical confirmation recovery", async () => {
+      ((globalThis as any).fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        headers: new Headers(),
+        json: async () => ({
+          error: {
+            code: "EMAIL_CONFIRMATION_REQUIRED",
+            recovery_url:
+              "https://www.oilpriceapi.com/auth/resend-confirmation",
+          },
+        }),
+      });
+
+      await expect(oilpricePrice("BRENT_CRUDE_USD")).resolves.toBe(
+        "#EMAIL_CONFIRMATION_REQUIRED: Confirm your email to continue. Request a new confirmation: https://www.oilpriceapi.com/auth/resend-confirmation",
+      );
+    });
+
+    it.each([
+      ["bare", async () => ({})],
+      ["malformed", async () => {
+        throw new SyntaxError("Malformed JSON");
+      }],
+    ])("fails a %s 403 safely to support", async (_name, json) => {
+      ((globalThis as any).fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        headers: new Headers(),
+        json,
+      });
+
+      await expect(oilpricePrice("BRENT_CRUDE_USD")).resolves.toBe(
+        "#ACCESS_DENIED: Access was denied for a reason the add-in could not verify. Use Test Key, then contact support: https://www.oilpriceapi.com/support",
       );
     });
 

--- a/tests/unit/http-error.test.ts
+++ b/tests/unit/http-error.test.ts
@@ -1,0 +1,129 @@
+import { classifyApiErrorResponse } from "../../src/utils/http-error";
+import fs from "node:fs";
+import path from "node:path";
+
+function response(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(
+    typeof body === "string" ? body : JSON.stringify(body),
+    { status, headers },
+  );
+}
+
+describe("shared API HTTP recovery classifier", () => {
+  it("parses a bounded error body exactly once", async () => {
+    const text = jest.fn().mockResolvedValue(
+      JSON.stringify({
+        error: {
+          code: "FORBIDDEN",
+          upgrade_url: "https://www.oilpriceapi.com/pricing",
+        },
+      }),
+    );
+    const json = jest.fn();
+    const fixture = {
+      status: 403,
+      headers: new Headers(),
+      text,
+      json,
+    } as unknown as Response;
+
+    await classifyApiErrorResponse(fixture);
+    expect(text).toHaveBeenCalledTimes(1);
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "API_ACCESS_SUSPENDED",
+      {
+        error: {
+          code: "API_ACCESS_SUSPENDED",
+          upgrade_url: "https://www.oilpriceapi.com/pricing?suspended=1",
+        },
+      },
+      "Access suspended",
+      "API_ACCESS_SUSPENDED",
+      "https://www.oilpriceapi.com/support",
+    ],
+    [
+      "EMAIL_CONFIRMATION_REQUIRED",
+      {
+        error: {
+          code: "EMAIL_CONFIRMATION_REQUIRED",
+          recovery_url:
+            "https://www.oilpriceapi.com/auth/resend-confirmation",
+        },
+      },
+      "Confirm email",
+      "EMAIL_CONFIRMATION_REQUIRED",
+      "https://www.oilpriceapi.com/auth/resend-confirmation",
+    ],
+    [
+      "FORBIDDEN",
+      {
+        error: {
+          code: "FORBIDDEN",
+          upgrade_url:
+            "https://www.oilpriceapi.com/pricing?feature=drilling",
+        },
+      },
+      "Upgrade required",
+      "UPGRADE_REQUIRED",
+      "https://www.oilpriceapi.com/pricing?feature=drilling",
+    ],
+  ])(
+    "maps %s for both worksheet and Test Key consumers",
+    async (_name, body, label, code, recovery) => {
+      const result = await classifyApiErrorResponse(response(403, body));
+      expect(result.label).toBe(label);
+      expect(result.code).toBe(code);
+      expect(result.message).toContain(recovery);
+    },
+  );
+
+  it.each([
+    ["bare", {}],
+    ["malformed", "{not-json"],
+    [
+      "untrusted recovery URL",
+      {
+        error: {
+          code: "EMAIL_CONFIRMATION_REQUIRED",
+          recovery_url: "https://attacker.invalid/confirm",
+        },
+      },
+    ],
+  ])("fails a %s 403 safely", async (_name, body) => {
+    const result = await classifyApiErrorResponse(response(403, body));
+    expect(result.label).toBe(
+      _name === "untrusted recovery URL" ? "Confirm email" : "Access denied",
+    );
+    expect(result.message).not.toContain("attacker.invalid");
+    expect(result.message).toContain("oilpriceapi.com");
+  });
+
+  it("turns Retry-After into an actionable 429 recovery", async () => {
+    const result = await classifyApiErrorResponse(
+      response(429, {}, { "Retry-After": "120" }),
+    );
+    expect(result.code).toBe("RATE_LIMITED");
+    expect(result.message).toMatch(/retry after about 2 minutes/i);
+  });
+
+  it("keeps custom functions and Test Key on the same classifier", () => {
+    const root = path.join(__dirname, "..", "..");
+    for (const file of [
+      "src/functions/functions.ts",
+      "src/taskpane/taskpane.ts",
+    ]) {
+      const source = fs.readFileSync(path.join(root, file), "utf8");
+      expect(source).toMatch(/import \{ classifyApiErrorResponse \}/);
+      expect(source).toMatch(/await classifyApiErrorResponse\(response\)/);
+      expect(source).not.toMatch(/status === 403/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- make worksheet errors actionable for invalid/expired keys, quota/entitlement, missing data, rate limits, timeouts, and browser/CORS failures
- use the shared versioned Excel attribution constants in both custom-function and task-pane requests
- align operator runbooks with the production edge header contract

## Red-green proof
- RED: `npm test -- --runInBand` -> 13 failed, 88 passed
- GREEN: `npm test -- --runInBand` -> 101 passed
- `npm run build`
- `npm run scan:secrets`
- `npm run validate:claims`
- `npx office-addin-manifest validate manifest.xml`

## Production dependency
- API edge CORS governance: OilpriceAPI/oilpriceapi-api#6642 (merged)
- AppSource/platform release gate remains tracked in #28

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer worksheet error messages with recovery steps, troubleshooting guidance, pricing links, and query suggestions.
  * Added a distinct “No data” response for unavailable results.
  * Improved request attribution for Excel add-in traffic.

* **Documentation**
  * Updated installation, deployment, support, and smoke-test guidance to verify the expanded request headers and preflight behavior.

* **Tests**
  * Added coverage to validate request attribution, documentation requirements, error guidance, and “No data” responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->