### PR TITLE
ci: move Excel release gates to Node 24

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -13,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "typescript": "^5.9.3",
         "webpack": "^5.109.2",
         "webpack-cli": "^7.2.2",
-        "webpack-dev-server": "^6.0.0"
+        "webpack-dev-server": "^6.0.0",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -16456,7 +16457,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "typescript": "^5.9.3",
     "webpack": "^5.109.2",
     "webpack-cli": "^7.2.2",
-    "webpack-dev-server": "^6.0.0"
+    "webpack-dev-server": "^6.0.0",
+    "yaml": "^2.9.0"
   }
 }

--- a/tests/unit/build-version.test.ts
+++ b/tests/unit/build-version.test.ts
@@ -1,5 +1,17 @@
 import * as fs from "fs";
 import * as path from "path";
+import { parse } from "yaml";
+
+type WorkflowStep = {
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+};
+
+type Workflow = {
+  permissions?: Record<string, unknown>;
+  jobs: Record<string, { steps: WorkflowStep[] }>;
+};
 
 describe("release version contract", () => {
   const root = path.join(__dirname, "..", "..");
@@ -105,14 +117,28 @@ describe("release version contract", () => {
 
   it("keeps dependency audit in the hosted release gate", () => {
     for (const file of ["test.yml", "github-pages.yml"]) {
-      const workflow = fs.readFileSync(
-        path.join(root, ".github", "workflows", file),
-        "utf8",
+      const workflow = parse(
+        fs.readFileSync(
+          path.join(root, ".github", "workflows", file),
+          "utf8",
+        ),
+      ) as Workflow;
+      const steps = Object.values(workflow.jobs).flatMap((job) => job.steps);
+      const checkout = steps.find(
+        (step) => step.uses === "actions/checkout@v6",
       );
-      expect(workflow).toContain("npm audit --audit-level=moderate");
-      expect(workflow).toContain("actions/checkout@v6");
-      expect(workflow).toContain("actions/setup-node@v6");
-      expect(workflow).toMatch(/node-version: ["']24["']/);
+      const setupNode = steps.find(
+        (step) => step.uses === "actions/setup-node@v6",
+      );
+
+      expect(workflow.permissions?.contents).toBe("read");
+      expect(checkout?.with?.["persist-credentials"]).toBe(false);
+      expect(setupNode?.with?.["node-version"]).toBe("24");
+      expect(
+        steps.some(
+          (step) => step.run === "npm audit --audit-level=moderate",
+        ),
+      ).toBe(true);
     }
   });
 

--- a/tests/unit/build-version.test.ts
+++ b/tests/unit/build-version.test.ts
@@ -110,6 +110,9 @@ describe("release version contract", () => {
         "utf8",
       );
       expect(workflow).toContain("npm audit --audit-level=moderate");
+      expect(workflow).toContain("actions/checkout@v6");
+      expect(workflow).toContain("actions/setup-node@v6");
+      expect(workflow).toMatch(/node-version: ["']24["']/);
     }
   });
 


### PR DESCRIPTION
## Summary
- move validation and Pages release workflows from deprecated Node 20 action runtimes to Node 24
- upgrade checkout/setup-node actions from v4 to v6
- bind both hosted workflows to this runtime contract in the release test

## Red-green proof
- RED: targeted release-contract test failed on `actions/checkout@v4`, `actions/setup-node@v4`, and Node 20
- GREEN: targeted contract 6/6
- full suite 117/117
- `npm audit --audit-level=moderate`: 0 vulnerabilities
- claims 29 surfaces, secret scan, webpack build, source/dist Microsoft manifest validation: green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build and deployment tooling to use newer workflow actions and Node.js 24.

* **Tests**
  * Added checks ensuring hosted workflows use the current action versions and Node.js 24 configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->