### PR TITLE
ci: move GitHub Pages actions to Node 24

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -39,13 +39,13 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/tests/unit/build-version.test.ts
+++ b/tests/unit/build-version.test.ts
@@ -139,6 +139,15 @@ describe("release version contract", () => {
           (step) => step.run === "npm audit --audit-level=moderate",
         ),
       ).toBe(true);
+      if (file === "github-pages.yml") {
+        expect(steps.map((step) => step.uses)).toEqual(
+          expect.arrayContaining([
+            "actions/configure-pages@v6",
+            "actions/upload-pages-artifact@v5",
+            "actions/deploy-pages@v5",
+          ]),
+        );
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- update the remaining GitHub Pages actions to their current Node 24 releases
- lock the exact action majors in the parsed workflow release contract

## Red-green proof
- RED: targeted release contract failed against configure-pages@v4, upload-pages-artifact@v3, and deploy-pages@v4
- GREEN: targeted 6/6; full 117/117
- `npm ci` and `npm audit --audit-level=moderate`: 0 vulnerabilities
- claims: 29; secret scan: green; webpack 5.109.2: green
- source and built Office manifests: valid

## Production evidence
Main Pages run 31496819184 was green but emitted the GitHub Node 20 deprecation annotation for these three actions. Official current releases are configure-pages v6.0.0, upload-pages-artifact v5.0.0 (internally upload-artifact v7), and deploy-pages v5.0.0; configure/deploy declare node24. A post-merge Pages run must be green with that annotation absent before this is considered complete.